### PR TITLE
Dispatch to allgather_packed_range from allgather for dynamic size types

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -77,6 +77,7 @@ include_HEADERS += parallel/include/timpi/communicator.h
 include_HEADERS += parallel/include/timpi/data_type.h
 include_HEADERS += parallel/include/timpi/message_tag.h
 include_HEADERS += parallel/include/timpi/op_function.h
+include_HEADERS += parallel/include/timpi/packing_forward.h
 include_HEADERS += parallel/include/timpi/packing.h
 include_HEADERS += parallel/include/timpi/parallel_communicator_specializations
 include_HEADERS += parallel/include/timpi/parallel_implementation.h

--- a/src/parallel/include/timpi/packing.h
+++ b/src/parallel/include/timpi/packing.h
@@ -21,6 +21,7 @@
 
 // TIMPI Includes
 #include "timpi/timpi_assert.h"
+#include "timpi/packing_forward.h"
 
 // C++ includes
 #include <cstddef>
@@ -43,7 +44,7 @@ namespace Parallel
  * Users will need to specialize this class for their particular data
  * types.
  */
-template <typename T>
+template <typename T, typename Enable>
 class Packing {
 public:
   // Should be an MPI sendable type in specializations, e.g.

--- a/src/parallel/include/timpi/packing_forward.h
+++ b/src/parallel/include/timpi/packing_forward.h
@@ -1,0 +1,40 @@
+// The TIMPI Message-Passing Parallelism Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#ifndef TIMPI_PACKING_FORWARD_H
+#define TIMPI_PACKING_FORWARD_H
+
+// FIXME: This *should* be in TIMPI namespace but we have libMesh
+// users which already partially specialized it
+namespace libMesh
+{
+namespace Parallel
+{
+/**
+ * Define data types and (un)serialization functions for use when
+ * encoding a potentially-variable-size object of type T.
+ *
+ * Users will need to specialize this class for their particular data
+ * types.
+ */
+template <typename T, typename Enable = void>
+class Packing;
+}
+}
+
+#endif // TIMPI_PACKING_FORWARD_H

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,15 +15,18 @@ if BUILD_DBG_MODE
   packed_range_unit_dbg_SOURCES = packed_range_unit.C
   parallel_sync_unit_dbg_SOURCES = parallel_sync_unit.C
   parallel_unit_dbg_SOURCES = parallel_unit.C
+  dispatch_to_packed_unit_dbg_SOURCES = dispatch_to_packed_unit.C
   message_tag_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
   packed_range_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
   parallel_sync_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
   parallel_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
+  dispatch_to_packed_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
 
   TESTS += message_tag_unit-dbg
   TESTS += packed_range_unit-dbg
   TESTS += parallel_sync_unit-dbg
   TESTS += parallel_unit-dbg
+  TESTS += dispatch_to_packed_unit-dbg
 endif
 
 if BUILD_DEVEL_MODE
@@ -31,15 +34,18 @@ if BUILD_DEVEL_MODE
   packed_range_unit_devel_SOURCES = packed_range_unit.C
   parallel_sync_unit_devel_SOURCES = parallel_sync_unit.C
   parallel_unit_devel_SOURCES = parallel_unit.C
+  dispatch_to_packed_unit_devel_SOURCES = dispatch_to_packed_unit.C
   message_tag_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
   packed_range_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
   parallel_sync_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
   parallel_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
+  dispatch_to_packed_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
 
   TESTS += message_tag_unit-devel
   TESTS += packed_range_unit-devel
   TESTS += parallel_sync_unit-devel
   TESTS += parallel_unit-devel
+  TESTS += dispatch_to_packed_unit-devel
 endif
 
 if BUILD_OPT_MODE
@@ -47,15 +53,18 @@ if BUILD_OPT_MODE
   packed_range_unit_opt_SOURCES = packed_range_unit.C
   parallel_sync_unit_opt_SOURCES = parallel_sync_unit.C
   parallel_unit_opt_SOURCES = parallel_unit.C
+  dispatch_to_packed_unit_opt_SOURCES = dispatch_to_packed_unit.C
   message_tag_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
   packed_range_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
   parallel_sync_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
   parallel_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
+  dispatch_to_packed_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
 
   TESTS += message_tag_unit-opt
   TESTS += packed_range_unit-opt
   TESTS += parallel_sync_unit-opt
   TESTS += parallel_unit-opt
+  TESTS += dispatch_to_packed_unit-opt
 endif
 
 check_PROGRAMS = $(TESTS)

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -1,0 +1,124 @@
+#include <timpi/timpi.h>
+
+#include <iterator>
+#include <vector>
+#include <set>
+
+#define TIMPI_UNIT_ASSERT(expr) \
+  if (!(expr)) \
+    timpi_error()
+
+namespace TIMPI
+{
+template <typename T>
+class StandardType<std::set<T>> : public DataType
+{
+public:
+  static const bool is_fixed_type = false;
+
+private:
+  StandardType(const std::set<T> * example = nullptr);
+};
+}
+
+namespace libMesh {
+namespace Parallel {
+template <typename T>
+class Packing<std::set<T>> {
+public:
+
+  static const unsigned int size_bytes = 4;
+
+  typedef T buffer_type;
+
+  static unsigned int
+  get_set_len (typename std::vector<T>::const_iterator in)
+  {
+    unsigned int set_len = reinterpret_cast<const unsigned char &>(in[size_bytes-1]);
+    for (signed int i=size_bytes-2; i >= 0; --i)
+      {
+        set_len *= 256;
+        set_len += reinterpret_cast<const unsigned char &>(in[i]);
+      }
+    return set_len;
+  }
+
+
+  static unsigned int
+  packed_size (typename std::vector<T>::const_iterator in)
+  {
+    return get_set_len(in) + size_bytes;
+  }
+
+  static unsigned int packable_size
+  (const std::set<T> & s,
+   const void *)
+  {
+    return s.size() + size_bytes;
+  }
+
+
+  template <typename Iter>
+  static void pack (const std::set<T> & b, Iter data_out,
+                    const void *)
+  {
+    unsigned int set_len = b.size();
+    for (unsigned int i=0; i != size_bytes; ++i)
+      {
+        *data_out++ = (set_len % 256);
+        set_len /= 256;
+      }
+    std::copy(b.begin(), b.end(), data_out);
+  }
+
+  static std::set<T>
+  unpack (typename std::vector<T>::const_iterator in, void *)
+  {
+    unsigned int set_len = get_set_len(in);
+
+    return std::set<T>(in + size_bytes, in + size_bytes + set_len);
+  }
+
+};
+
+
+} // namespace Parallel
+
+} // namespace libMesh
+
+using namespace TIMPI;
+
+Communicator *TestCommWorld;
+
+  void testContainerAllGather()
+  {
+    std::vector<std::set<unsigned int>> vals;
+    const unsigned int my_rank = TestCommWorld->rank();
+
+    std::vector<int> data_vec(my_rank + 1);
+    std::iota(data_vec.begin(), data_vec.end(), 0);
+    TestCommWorld->allgather(std::set<unsigned int>(data_vec.begin(), data_vec.end()), vals);
+
+    const std::size_t comm_size = TestCommWorld->size();
+    const std::size_t vec_size = vals.size();
+    TIMPI_UNIT_ASSERT(comm_size == vec_size);
+
+    for (std::size_t i = 0; i < vec_size; ++i)
+    {
+      const auto & current_set = vals[i];
+      unsigned int value = 0;
+      for (auto number : current_set)
+        TIMPI_UNIT_ASSERT(number == value++);
+    }
+  }
+
+
+int main(int argc, const char * const * argv)
+{
+  TIMPI::TIMPIInit init(argc, argv);
+  TestCommWorld = &init.comm();
+
+  testContainerAllGather();
+
+  return 0;
+}

--- a/test/packed_range_unit.C
+++ b/test/packed_range_unit.C
@@ -5,7 +5,7 @@
 
 #define TIMPI_UNIT_ASSERT(expr) \
   if (!(expr)) \
-    timpi_error();
+    timpi_error()
 
 template <typename T>
 struct null_output_iterator
@@ -26,7 +26,6 @@ struct null_output_iterator
   // construct one or have any of its methods called.
   null_output_iterator & operator*() { return *this; }
 };
-
 
 namespace libMesh {
 namespace Parallel {
@@ -144,6 +143,23 @@ Communicator *TestCommWorld;
        (std::string*)NULL);
   }
 
+  void testContainerAllGather()
+  {
+    // This method uses a specialized allgather method that is only defined
+    // when we have MPI
+#ifdef TIMPI_HAVE_MPI
+    std::vector<std::string> vals;
+    const unsigned int my_rank = TestCommWorld->rank();
+    TestCommWorld->allgather(std::string(my_rank+1, '0' + my_rank), vals);
+
+    const std::size_t comm_size = TestCommWorld->size();
+    const std::size_t vec_size = vals.size();
+    TIMPI_UNIT_ASSERT(comm_size == vec_size);
+
+    for (std::size_t i = 0; i < vec_size; ++i)
+      TIMPI_UNIT_ASSERT(vals[i] == std::string(i + 1, '0' + i));
+#endif
+  }
 
   void testContainerSendReceive()
   {
@@ -189,6 +205,7 @@ int main(int argc, const char * const * argv)
 
   testNullAllGather();
   testNullSendReceive();
+  testContainerAllGather();
   testContainerSendReceive();
 
   return 0;


### PR DESCRIPTION
This works currently by:
- Adding a `is_fixed_type` bool to StandardType classes
- doing SFINAE on Communicator::allgather based on `is_fixed_type`

This also adds default `typename Enable = void` template arguments to
`StandardType` and `Packing`. This is useful for enabling/disabling
specializations based on whether data members are fixed sizes or not.
I'm thinking of an example like `DualNumber<T,D>` where that class
may be fixed-size depending on whether D is fixed-size