### PR TITLE
Add support for a timpi-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,13 +19,17 @@ AUX_DIST        += build-aux/ltmain.sh
 pkgconfigdir   = $(libdir)/pkgconfig
 pkgconfig_DATA = timpi.pc
 
+# Support for timpi-config in $(exec_prefix)/bin
+timpi_configdir      = $(exec_prefix)/bin
+timpi_config_SCRIPTS = bin/timpi-config
+
 # Support 'make install prefix=/other/path' with pkgconfig
 install-data-hook:
 	@if (test "x$(prefix)" != "x@prefix@"); then \
 	  oldprefix="@prefix@" ; \
 	  newprefix="$(prefix)" ; \
 	  cd $(DESTDIR)$(libdir)/pkgconfig ; \
-	  for genfile in $(pkgconfig_DATA); do \
+	  for genfile in $(pkgconfig_DATA) $(DESTDIR)$(prefix)/bin/timpi-config; do \
 	  echo " " ; \
 	    echo " *** replacing $$oldprefix" ; \
 	    echo " ***      with $$newprefix" ; \
@@ -35,6 +39,8 @@ install-data-hook:
 	    cd $(DESTDIR)$(prefix) && mv $$genfile.replaced $$genfile ; \
           done ; \
 	fi
+	cat $(DESTDIR)$(timpi_configdir)/timpi-config | $(SED) "s/has_been_installed=no/has_been_installed=yes/g" > $(DESTDIR)$(timpi_configdir)/timpi-config.installed
+	mv $(DESTDIR)$(timpi_configdir)/timpi-config.installed $(DESTDIR)$(timpi_configdir)/timpi-config && chmod +x $(DESTDIR)$(timpi_configdir)/timpi-config
 
 # Additional files to be deleted by 'make distclean'
 DISTCLEANFILES  = _configs.sed

--- a/bin/timpi-config.in
+++ b/bin/timpi-config.in
@@ -1,0 +1,161 @@
+#!/bin/sh
+
+#
+# values substituted from configure
+#
+host=@host@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+legacyinclude=@enablelegacyincludepaths@
+builddir=@abs_top_builddir@
+has_been_installed=no
+
+#
+# Define the usage() function
+#
+usage ()
+{
+  echo "usage: $0 --cppflags --cxxflags --include --libs"
+  echo "       $0 --cxx"
+  echo "       $0 --cc"
+  echo "       $0 --fc"
+  echo "       $0 --fflags"
+  echo "       $0 --version"
+  echo "       $0 --host"
+  echo "       $0 --ldflags"
+  exit
+}
+
+#
+# Need at least one command-line argument
+#
+if [ "$#" = "0" ] ; then
+    usage $0
+fi
+
+#
+# Need a valid METHOD
+#
+if (test "x$METHOD" = x); then
+    #echo "No METHOD specified - defaulting to opt"
+    METHOD=opt
+fi
+
+case "$METHOD" in
+    optimized|opt)
+	CXXFLAGS="@CXXFLAGS_OPT@"
+	CPPFLAGS="@CPPFLAGS_OPT@"
+	CFLAGS="@CFLAGS_OPT@"
+	libext="_opt"
+	;;
+    debug|dbg)
+	CXXFLAGS="@CXXFLAGS_DBG@"
+	CPPFLAGS="@CPPFLAGS_DBG@"
+	CFLAGS="@CFLAGS_DBG@"
+	libext="_dbg"
+	;;
+    devel)
+	CXXFLAGS="@CXXFLAGS_DEVEL@"
+	CPPFLAGS="@CPPFLAGS_DEVEL@"
+	CFLAGS="@CFLAGS_DEVEL@"
+	libext="_devel"
+	;;
+    profiling|pro|prof)
+	CXXFLAGS="@CXXFLAGS_PROF@"
+	CPPFLAGS="@CPPFLAGS_PROF@"
+	CFLAGS="@CFLAGS_PROF@"
+	libext="_prof"
+	;;
+    oprofile|oprof)
+	CXXFLAGS="@CXXFLAGS_OPROF@"
+	CPPFLAGS="@CPPFLAGS_OPROF@"
+	CFLAGS="@CFLAGS_OPROF@"
+	libext="_oprof"
+	;;
+    *)
+	echo "ERROR: Unknown \$METHOD: $METHOD"
+	echo "  should be one of: <opt,dbg,devel,prof,oprof>"
+	exit 1
+	;;
+esac
+
+#
+# Process the command-line arguments, build up
+# return_val
+#
+return_val=""
+
+while [ "x$1" != "x" ]; do
+    case "$1" in
+	"--cxx")
+	    return_val="@CXX@ $return_val"
+	    ;;
+
+	"--cc")
+	    return_val="@CC@ $return_val"
+	    ;;
+
+	"--f77")
+	    return_val="@F77@ $return_val"
+	    ;;
+
+	"--fc")
+	    return_val="@FC@ $return_val"
+	    ;;
+
+	"--cppflags")
+	    return_val="${CPPFLAGS} $return_val"
+	    ;;
+
+	"--cxxflags")
+	    return_val="${CXXFLAGS} $return_val"
+	    ;;
+
+	"--cflags")
+	    return_val="${CFLAGS} $return_val"
+	    ;;
+
+	"--fflags")
+	    return_val="@FFLAGS@ $return_val"
+	    ;;
+
+	"--include")
+	    # handle legacy include paths when needed.
+	    if (test "x$legacyinclude" = "xyes"); then
+		return_val="-I${includedir}/timpi $return_val"
+	    fi
+	    return_val="-I${includedir}
+ 	                @timpi_optional_INCLUDES@
+                        $return_val"
+	    ;;
+
+	"--libs")
+	    return_val="-Wl,-rpath,${libdir} -L${libdir} -ltimpi${libext} @timpi_optional_LIBS@ $return_val"
+	    ;;
+
+	"--ldflags")
+	    return_val="@timpi_LDFLAGS@ $return_val"
+	    ;;
+
+	"--version")
+	    return_val="@VERSION@"
+	    ;;
+
+	"--host")
+	    return_val="$host"
+	    ;;
+
+	*)
+	    echo "Unknown argument: $1"
+	    usage $0
+    esac
+    shift
+done
+
+echo $return_val
+
+# Local Variables:
+# mode: shell-script
+# End:

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,8 @@ AC_CONFIG_FILES([
   test/Makefile
   ])
 
+AC_CONFIG_FILES(bin/timpi-config, [chmod +x bin/timpi-config])
+
 # Must still call AC_OUTPUT() after generating all the files
 AC_OUTPUT()
 


### PR DESCRIPTION
This allows querying the necessary TIMPI dependencies when configuring a package that may depend on TIMPI, e.g. MetaPhysicL.