### PR TITLE
Add Communicator::sum(std::unordered_map)

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -230,6 +230,13 @@ private:
   // Keep track of duplicate/split operations so we know when to free
   bool _I_duped_it;
 
+  /**
+   * Private implementation function called by the map-based sum()
+   * specializations.
+   */
+  template <typename Map>
+  void map_sum(Map & data) const;
+
   // Communication operations:
 public:
 

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -39,6 +39,7 @@
 // These could be forward declarations if only that wasn't illegal
 #include <complex> // for specializations
 #include <set>
+#include <unordered_map>
 
 namespace TIMPI
 {

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -86,6 +86,10 @@
     inline
     void sum(std::map<K,V,C,A> &r) const;
 
+    template <typename K, typename V, typename H, typename E, typename A>
+    inline
+    void sum(std::unordered_map<K,V,H,E,A> &r) const;
+
     template <typename T, typename C, typename A>
     inline
     void set_union(std::set<T,C,A> &data,

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -2532,6 +2532,28 @@ inline void Communicator::sum(std::map<K,V,C,A> & data) const
 
 
 
+template <typename K, typename V, typename H, typename E, typename A>
+inline void Communicator::sum(std::unordered_map<K,V,H,E,A> & data) const
+{
+  if (this->size() > 1)
+    {
+      TIMPI_LOG_SCOPE("sum(unordered_map)", "Parallel");
+
+      // There may be different keys on different processors, so we
+      // first gather all the (key, value) pairs and then insert
+      // them, summing repeated keys, back into the map.
+      std::vector<std::pair<K,V>> vecdata(data.begin(), data.end());
+
+      this->allgather(vecdata, /*identical_buffer_sizes=*/false);
+
+      data.clear();
+      for (const auto & pr : vecdata)
+        data[pr.first] += pr.second;
+    }
+}
+
+
+
 template <typename T, typename C, typename A>
 inline void Communicator::set_union(std::set<T,C,A> & data,
                                     const unsigned int root_id) const

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -25,10 +25,10 @@ std::vector<std::string> pt_number;
     pt_number[9] = "Nine";
   }
 
-
+  template <class Map>
   void testSum()
   {
-    std::map<int, int> data;
+    Map data;
 
     int N = TestCommWorld->size();
 
@@ -691,7 +691,8 @@ int main(int argc, const char * const * argv)
 
   setUp();
 
-  testSum();
+  testSum<std::map<int,int>>();
+  testSum<std::unordered_map<int,int>>();
   testGather();
   testAllGather();
   testGatherString();


### PR DESCRIPTION
The `map` and `unordered_map` `sum()` implementations are basically identical, so they both simply use the private `Communicator::map_sum()` implementation function.
