### PR TITLE
Communicator::broadcast(map): Save one communication

### DIFF
--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -1766,8 +1766,7 @@ inline void Communicator::broadcast(std::map<T1,T2,C,A> & data,
   if (this->rank() != root_id)
     {
       data.clear();
-      for (const auto & pr : comm_data)
-        data[pr.first] = pr.second;
+      data.insert(comm_data.begin(), comm_data.end());
     }
 }
 

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -1754,33 +1754,20 @@ inline void Communicator::broadcast(std::map<T1,T2,C,A> & data,
   std::size_t data_size=data.size();
   this->broadcast(data_size, root_id);
 
-  std::vector<T1> pair_first; pair_first.reserve(data_size);
-  std::vector<T2> pair_second; pair_first.reserve(data_size);
+  std::vector<std::pair<T1,T2>> comm_data;
 
   if (root_id == this->rank())
-    {
-      for (const auto & pr : data)
-        {
-          pair_first.push_back(pr.first);
-          pair_second.push_back(pr.second);
-        }
-    }
+    comm_data.assign(data.begin(), data.end());
   else
-    {
-      pair_first.resize(data_size);
-      pair_second.resize(data_size);
-    }
+    comm_data.resize(data_size);
 
-  this->broadcast(pair_first, root_id);
-  this->broadcast(pair_second, root_id);
-
-  timpi_assert(pair_first.size() == pair_first.size());
+  this->broadcast(comm_data, root_id);
 
   if (this->rank() != root_id)
     {
       data.clear();
-      for (std::size_t i=0; i<pair_first.size(); ++i)
-        data[pair_first[i]] = pair_second[i];
+      for (const auto & pr : comm_data)
+        data[pr.first] = pr.second;
     }
 }
 

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -133,19 +133,36 @@ std::vector<std::string> pt_number;
 
   void testBroadcast()
   {
-    std::vector<unsigned int> src(3), dest(3);
+    {
+      std::vector<unsigned int> src(3), dest(3);
 
-    src[0]=0;
-    src[1]=1;
-    src[2]=2;
+      src[0]=0;
+      src[1]=1;
+      src[2]=2;
 
-    if (TestCommWorld->rank() == 0)
-      dest = src;
+      if (TestCommWorld->rank() == 0)
+        dest = src;
 
-    TestCommWorld->broadcast(dest);
+      TestCommWorld->broadcast(dest);
 
-    for (std::size_t i=0; i<src.size(); i++)
-      TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
+      for (std::size_t i=0; i<src.size(); i++)
+        TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
+    }
+
+    {
+      std::map<int, int> src, dest;
+      src[0]=0;
+      src[1]=1;
+      src[2]=2;
+
+      if (TestCommWorld->rank() == 0)
+        dest = src;
+
+      TestCommWorld->broadcast(dest);
+
+      for (std::size_t i=0; i<src.size(); i++)
+        TIMPI_UNIT_ASSERT( src[i] == dest[i] );
+    }
   }
 
 

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -131,38 +131,19 @@ std::vector<std::string> pt_number;
 
 
 
-  void testBroadcast()
+  template <class Container>
+  void testBroadcast(Container && src)
   {
-    {
-      std::vector<unsigned int> src(3), dest(3);
+    Container dest = src;
 
-      src[0]=0;
-      src[1]=1;
-      src[2]=2;
+    // Clear dest on non-root ranks
+    if (TestCommWorld->rank() != 0)
+      dest.clear();
 
-      if (TestCommWorld->rank() == 0)
-        dest = src;
+    TestCommWorld->broadcast(dest);
 
-      TestCommWorld->broadcast(dest);
-
-      for (std::size_t i=0; i<src.size(); i++)
-        TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
-    }
-
-    {
-      std::map<int, int> src, dest;
-      src[0]=0;
-      src[1]=1;
-      src[2]=2;
-
-      if (TestCommWorld->rank() == 0)
-        dest = src;
-
-      TestCommWorld->broadcast(dest);
-
-      for (std::size_t i=0; i<src.size(); i++)
-        TIMPI_UNIT_ASSERT( src[i] == dest[i] );
-    }
+    for (std::size_t i=0; i<src.size(); i++)
+      TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
   }
 
 
@@ -716,7 +697,8 @@ int main(int argc, const char * const * argv)
   testAllGatherVectorString();
   testAllGatherEmptyVectorString();
   testAllGatherHalfEmptyVectorString();
-  testBroadcast();
+  testBroadcast<std::vector<unsigned int>>({0,1,2});
+  testBroadcast<std::map<int, int>>({{0,0}, {1,1}, {2,2}});
   testBroadcastNestedType();
   testScatter();
   testBarrier();


### PR DESCRIPTION
All other things being equal, it's probably more efficient to broadcast one slightly-larger-than-necessary (due to padding) message than two smaller messages.

Also adds a unit test of Communicator::broadcast(map)
