### PR TITLE
Add back old map broadcast method

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -239,9 +239,25 @@ private:
 
   /**
    * Private implementation function called by the map-based broadcast()
-   * specializations.
+   * specializations. This is_fixed_type variant saves a communication by broadcasting pairs
    */
-  template <typename Map>
+  template <typename Map,
+            typename std::enable_if<StandardType<typename Map::key_type>::is_fixed_type &&
+                                        StandardType<typename Map::mapped_type>::is_fixed_type,
+                                    int>::type = 0>
+  void map_broadcast(Map & data,
+                     const unsigned int root_id) const;
+
+  /**
+   * Private implementation function called by the map-based broadcast()
+   * specializations. This !is_fixed_type variant makes two broadcasts, which is slower
+   * but gives more control over reach broadcast (e.g. we may need to specialize for either
+   * key_type or mapped_type)
+   */
+  template <typename Map,
+            typename std::enable_if<!(StandardType<typename Map::key_type>::is_fixed_type &&
+                                      StandardType<typename Map::mapped_type>::is_fixed_type),
+                                    int>::type = 0>
   void map_broadcast(Map & data,
                      const unsigned int root_id) const;
 

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -700,7 +700,9 @@ int main(int argc, const char * const * argv)
   testAllGatherHalfEmptyVectorString();
   testBroadcast<std::vector<unsigned int>>({0,1,2});
   testBroadcast<std::map<int, int>>({{0,0}, {1,1}, {2,2}});
+  testBroadcast<std::map<int, std::string>>({{0,"foo"}, {1,"bar"}, {2,"baz"}});
   testBroadcast<std::unordered_map<int, int>>({{0,0}, {1,1}, {2,2}});
+  testBroadcast<std::unordered_map<int, std::string>>({{0,"foo"}, {1,"bar"}, {2,"baz"}});
   testBroadcastNestedType();
   testScatter();
   testBarrier();


### PR DESCRIPTION
Use SFINAE based on whether the map types are fixed types in order
to determine whether to call @jwpeterson's single broadcast method
or the old double broadcast method