### PR TITLE
Add Communicator::max(map)

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -278,6 +278,28 @@ private:
                      const unsigned int root_id,
                      const bool identical_sizes) const;
 
+  /**
+   * Private implementation function called by the map-based max()
+   * specializations.  This is_fixed_type variant saves a
+   * communication by broadcasting pairs
+   */
+  template <typename Map,
+            typename std::enable_if<StandardType<typename Map::key_type>::is_fixed_type &&
+                                    StandardType<typename Map::mapped_type>::is_fixed_type,
+                                    int>::type = 0>
+  void map_max(Map & data) const;
+
+  /**
+   * Private implementation function called by the map-based max()
+   * specializations.  This !is_fixed_type variant calls allgather
+   * twice: once for the keys and once for the values.
+   */
+  template <typename Map,
+            typename std::enable_if<!(StandardType<typename Map::key_type>::is_fixed_type &&
+                                      StandardType<typename Map::mapped_type>::is_fixed_type),
+                                    int>::type = 0>
+  void map_max(Map & data) const;
+
   // Communication operations:
 public:
 

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -62,6 +62,14 @@
     inline
     void max(std::vector<bool,A> &r) const;
 
+    template <typename K, typename V, typename C, typename A>
+    inline
+    void max(std::map<K,V,C,A> & data) const;
+
+    template <typename K, typename V, typename H, typename E, typename A>
+    inline
+    void max(std::unordered_map<K,V,H,E,A> & data) const;
+
     void maxloc(bool &r,
                 unsigned int &max_id) const;
 

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -330,6 +330,48 @@ void testGather()
 
 
 
+  template <class Map>
+  void testMapMax ()
+  {
+    Map data;
+
+    int rank = TestCommWorld->rank();
+    int N = TestCommWorld->size();
+
+    // On each proc, the map has the single entry (rank, rank)
+    data[rank] = rank;
+
+    // Compute the max
+    TestCommWorld->max(data);
+
+    // After calling max, there should be an entry for each rank
+    for (int p=0; p<N; ++p)
+      TIMPI_UNIT_ASSERT (data[p] == p);
+  }
+
+
+
+  template <class Map>
+  void testNonFixedTypeMapMax ()
+  {
+    Map data;
+
+    int rank = TestCommWorld->rank();
+    int N = TestCommWorld->size();
+
+    // On each proc, the map has a single entry, e.g. ("key0", 0)
+    data[std::string("key") + std::to_string(rank)] = rank;
+
+    // Compute the max
+    TestCommWorld->max(data);
+
+    // After calling max, there should be an entry for each rank
+    for (int p=0; p<N; ++p)
+      TIMPI_UNIT_ASSERT (data[std::string("key") + std::to_string(p)] == p);
+  }
+
+
+
   void testMinloc ()
   {
     int min = (TestCommWorld->rank() + 1) % TestCommWorld->size();
@@ -730,6 +772,10 @@ int main(int argc, const char * const * argv)
   testBarrier();
   testMin();
   testMax();
+  testMapMax<std::map<int, int>>();
+  testMapMax<std::unordered_map<int, int>>();
+  testNonFixedTypeMapMax<std::map<std::string,int>>();
+  testNonFixedTypeMapMax<std::unordered_map<std::string,int>>();
   testMinloc();
   testMaxloc();
   testMinlocDouble();


### PR DESCRIPTION
Similar to broadcast(map) and sum(map), this is based on a shared private Communicator::map_max() implementation so that it works for both std::map and std::unordered_map.

There are two versions of Communicator::map_max(), one for fixed types and one for non-fixed types. The SFINAE principal is used to control which version gets called.
