### PR TITLE
export TIMPI_RUN in Travis MATRIX_EVAL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           packages:
             - g++-7 openmpi-bin openmpi-common libopenmpi-dev
       env:
-        - MATRIX_EVAL="CC=mpicc && CXX=mpicxx && TIMPI_RUN='mpirun -np 4'"
+        - MATRIX_EVAL="CC=mpicc && CXX=mpicxx && export TIMPI_RUN='mpirun -np 4'"
 
     - os: linux
       addons:

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -261,7 +261,8 @@ private:
                                     StandardType<typename Map::mapped_type>::is_fixed_type,
                                     int>::type = 0>
   void map_broadcast(Map & data,
-                     const unsigned int root_id) const;
+                     const unsigned int root_id,
+                     const bool identical_sizes) const;
 
   /**
    * Private implementation function called by the map-based broadcast()
@@ -274,7 +275,8 @@ private:
                                       StandardType<typename Map::mapped_type>::is_fixed_type),
                                     int>::type = 0>
   void map_broadcast(Map & data,
-                     const unsigned int root_id) const;
+                     const unsigned int root_id,
+                     const bool identical_sizes) const;
 
   // Communication operations:
 public:
@@ -1009,12 +1011,14 @@ public:
    * Take a local value and broadcast it to all processors.
    * Optionally takes the \p root_id processor, which specifies
    * the processor initiating the broadcast.
-   * If \p data is a vector, the user is responsible for resizing it
-   * on all processors, except in the case when \p data is a vector
-   * of strings.
+   *
+   * If \p data is a container, it will be resized on target
+   * processors.  When using pre-sized target containers, specify
+   * \p identical_sizes=true on all processors for an optimization.
    */
   template <typename T>
-  inline void broadcast(T & data, const unsigned int root_id=0) const;
+  inline void broadcast(T & data, const unsigned int root_id=0,
+                        const bool identical_sizes=false) const;
 
   /**
    * Blocking-broadcast range-of-pointers to one processor.  This

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -311,37 +311,44 @@
     template <typename T>
     inline
     void broadcast(std::basic_string<T> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     template <typename T, typename A>
     inline
     void broadcast(std::vector<T,A> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     template <typename T, typename A>
     inline
     void broadcast(std::vector<std::basic_string<T>,A> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     template <typename T, typename A1, typename A2>
     inline
     void broadcast(std::vector<std::vector<T,A1>,A2> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     template <typename T, typename C, typename A>
     inline
     void broadcast(std::set<T,C,A> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     template <typename T1, typename T2, typename C, typename A>
     inline
     void broadcast(std::map<T1,T2,C,A> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     template <typename K, typename V, typename H, typename E, typename A>
     inline
     void broadcast(std::unordered_map<K,V,H,E,A> &data,
-                   const unsigned int root_id=0) const;
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
 
     // In new overloaded function template entries we have to
     // re-specify the default arguments


### PR DESCRIPTION
Hopefully this way it'll get passed down to our run_unit_tests.sh and
we'll *actually* be running them in parallel.

Simply setting the variable without exporting it in #12 didn't work.

With luck we'll now see the tests fail, as there's an overzealous unit test (or IMHO an insufficiently flexible API) among the ones @jwpeterson introduced in #10.  I'll commit a fix for the API in a separate PR.