### PR TITLE
Nonblocking vec<vec> receives + syncs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,6 +87,7 @@ include_HEADERS += parallel/include/timpi/post_wait_dereference_shared_ptr.h
 include_HEADERS += parallel/include/timpi/post_wait_dereference_tag.h
 include_HEADERS += parallel/include/timpi/post_wait_free_buffer.h
 include_HEADERS += parallel/include/timpi/post_wait_unpack_buffer.h
+include_HEADERS += parallel/include/timpi/post_wait_unpack_nested_buffer.h
 include_HEADERS += parallel/include/timpi/post_wait_work.h
 include_HEADERS += parallel/include/timpi/request.h
 include_HEADERS += parallel/include/timpi/standard_type.h

--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -203,6 +203,10 @@ void push_parallel_vector_data(const Communicator & comm,
         }
     }
 
+  // In serial we've now acted on all our data.
+  if (comm.size() == 1)
+    return;
+
   bool sends_complete = reqs.empty();
   bool started_barrier = false;
   Request barrier_request;

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -551,19 +551,34 @@ public:
    *
    * Otherwise - if there is no message to receive it returns false
    *
-   * Note: The buf does NOT need to properly sized before this call
+   * Note: The buf does NOT need to be properly sized before this call
    * this will resize the buffer automatically
    *
-   * If \p T is a container, container-of-containers, etc., then
-   * \p type should be the DataType of the underlying fixed-size
-   * entries in the container(s).
+   * @param src_processor_id The pid to receive from or "any".
+   * will be set to the actual src being received from
+   * @param buf The buffer to receive into
+   * @param req The request to use
+   * @param tag The tag to use
+   */
+  template <typename T, typename A>
+  inline
+  bool possibly_receive (unsigned int & src_processor_id,
+                         std::vector<T,A> & buf,
+                         Request & req,
+                         const MessageTag & tag) const;
+
+  /**
+   * Nonblocking-receive from one processor with user-defined type.
+   *
+   * As above, but with manually-specified data type.
    *
    * @param src_processor_id The pid to receive from or "any".
-   * will be set to the actual src being receieved from
+   * will be set to the actual src being received from
    * @param buf The buffer to receive into
    * @param type The intrinsic datatype to receive
    * @param req The request to use
    * @param tag The tag to use
+
    */
   template <typename T, typename A>
   inline

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -300,6 +300,12 @@ private:
                                     int>::type = 0>
   void map_max(Map & data) const;
 
+  // Utility function for determining size for buffering of
+  // vector<vector<T>> into vector<char> via MPI_Pack*
+  template <typename T, typename A1, typename A2>
+  int packed_size_of(const std::vector<std::vector<T,A1>,A2> & buf,
+                     const DataType & type) const;
+
   // Communication operations:
 public:
 

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -305,8 +305,21 @@
                     const DataType &type,
                     const MessageTag &tag=any_tag) const;
 
-// FIXME - non-blocking receive of vector-of-vectors is currently unimplemented
-/*
+    template <typename T, typename A1, typename A2>
+    inline
+    bool possibly_receive (unsigned int & src_processor_id,
+                           std::vector<std::vector<T,A1>,A2> & buf,
+                           Request & req,
+                           const MessageTag & tag) const;
+
+    template <typename T, typename A1, typename A2>
+    inline
+    bool possibly_receive (unsigned int & src_processor_id,
+                           std::vector<std::vector<T,A1>,A2> & buf,
+                           const DataType & type,
+                           Request & req,
+                           const MessageTag & tag) const;
+
     template <typename T, typename A1, typename A2>
     inline
     void receive (const unsigned int src_processor_id,
@@ -314,7 +327,6 @@
                   const DataType &type,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
-*/
 
     template <typename T>
     inline

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -116,6 +116,13 @@
     inline
     void set_union(std::map<T1,T2,C,A> &data) const;
 
+    template <typename T, typename A1, typename A2>
+    inline
+    bool possibly_receive (unsigned int & src_processor_id,
+                           std::vector<std::vector<T,A1>,A2> & buf,
+                           Request & req,
+                           const MessageTag & tag) const;
+
 // We only need to bother with many of these specializations if we're
 // actually in parallel.
 #ifdef TIMPI_HAVE_MPI
@@ -304,13 +311,6 @@
                     std::vector<std::vector<T,A1>,A2> &buf,
                     const DataType &type,
                     const MessageTag &tag=any_tag) const;
-
-    template <typename T, typename A1, typename A2>
-    inline
-    bool possibly_receive (unsigned int & src_processor_id,
-                           std::vector<std::vector<T,A1>,A2> & buf,
-                           Request & req,
-                           const MessageTag & tag) const;
 
     template <typename T, typename A1, typename A2>
     inline

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -124,14 +124,14 @@
     void send (const unsigned int dest_processor_id,
                const std::basic_string<T> & buf,
                const MessageTag &tag=no_tag) const;
- 
+
     template<typename T>
     inline
     void send (const unsigned int dest_processor_id,
                const std::basic_string<T> & buf,
                Request &req,
                const MessageTag &tag=no_tag) const;
- 
+
     template <typename T, typename C, typename A>
     inline
     void send (const unsigned int dest_processor_id,
@@ -256,7 +256,7 @@
                   const DataType &type,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
- 
+
     template <typename T, typename A>
     inline
     Status receive (const unsigned int src_processor_id,

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -3522,6 +3522,19 @@ inline void Communicator::allgather_packed_range(Context * context,
 template <typename T, typename A>
 inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
                                             std::vector<T,A> & buf,
+                                            Request & req,
+                                            const MessageTag & tag) const
+{
+  T * dataptr = buf.empty() ? nullptr : buf.data();
+
+  return this->possibly_receive(src_processor_id, buf, StandardType<T>(dataptr), req, tag);
+}
+
+
+
+template <typename T, typename A>
+inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
+                                            std::vector<T,A> & buf,
                                             const DataType & type,
                                             Request & req,
                                             const MessageTag & tag) const

--- a/src/parallel/include/timpi/post_wait_unpack_nested_buffer.h
+++ b/src/parallel/include/timpi/post_wait_unpack_nested_buffer.h
@@ -1,0 +1,95 @@
+// The TIMPI Message-Passing Parallelism Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#ifndef TIMPI_POST_WAIT_UNPACK_NESTED_BUFFER_H
+#define TIMPI_POST_WAIT_UNPACK_NESTED_BUFFER_H
+
+// TIMPI includes
+#include "timpi/communicator.h"
+#include "timpi/post_wait_work.h"
+#include "timpi/standard_type.h"
+
+namespace TIMPI
+{
+
+// PostWaitWork specialization for MPI_Unpack of nested buffers.
+// Container will most likely be vector<vector<T>>
+template <typename Container>
+struct PostWaitUnpackNestedBuffer : public PostWaitWork {
+  PostWaitUnpackNestedBuffer(const std::vector<char> & buffer,
+                             Container & out,
+                             const DataType & T_type,
+                             const Communicator & comm_in) :
+    recvbuf(buffer), recv(out), comm(comm_in) {
+      timpi_call_mpi(MPI_Type_dup(T_type, &(type.operator data_type &())));
+    }
+
+  ~PostWaitUnpackNestedBuffer() {
+#ifdef TIMPI_HAVE_MPI
+    // Not bothering with return type; we can't throw in a destructor
+    MPI_Type_free(&(type.operator data_type &()));
+#endif
+  }
+
+  virtual void run() override {
+  // We should at least have one header datum, for outer vector size
+  timpi_assert (!recvbuf.empty());
+
+  // Unpack the received buffer
+  int bufsize = cast_int<int>(recvbuf.size());
+  int recvsize, pos=0;
+  timpi_call_mpi
+    (MPI_Unpack (recvbuf.data(), bufsize, &pos,
+                 &recvsize, 1, StandardType<unsigned int>(),
+                 comm.get()));
+
+  // ... size the outer buffer
+  recv.resize (recvsize);
+
+  const std::size_t n_vecs = recvsize;
+  for (std::size_t i = 0; i != n_vecs; ++i)
+    {
+      int subvec_size;
+
+      timpi_call_mpi
+        (MPI_Unpack (recvbuf.data(), bufsize, &pos,
+                     &subvec_size, 1,
+                     StandardType<unsigned int>(),
+                     comm.get()));
+
+      // ... size the inner buffer
+      recv[i].resize (subvec_size);
+
+      // ... unpack the inner buffer if it is not empty
+      if (!recv[i].empty())
+        timpi_call_mpi
+          (MPI_Unpack (recvbuf.data(), bufsize, &pos, recv[i].data(),
+                       subvec_size, type, comm.get()));
+    }
+  }
+
+private:
+  const std::vector<char> & recvbuf;
+  Container & recv;
+  DataType type;
+  const Communicator & comm;
+};
+
+} // namespace TIMPI
+
+#endif // TIMPI_POST_WAIT_UNPACK_NESTED_BUFFER_H


### PR DESCRIPTION
This lets us get rid of the parallel_sync.h overloads with the alltoall step, so now every single sync function there uses the NBX algorithm as adapted by @friedmud.  Fixes #18.