### PR TITLE
automake fixups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,21 +44,4 @@ install-data-hook:
 
 # Additional files to be deleted by 'make distclean'
 DISTCLEANFILES  = _configs.sed
-
-# Files to be deleted by 'make maintainer-clean'
-MAINTAINERCLEANFILES  = aclocal.m4
-MAINTAINERCLEANFILES += aminclude.am
-MAINTAINERCLEANFILES += autom4te.cache/*
-MAINTAINERCLEANFILES += $(AUX_DIST)
-MAINTAINERCLEANFILES += config.log
-MAINTAINERCLEANFILES += config.status
-MAINTAINERCLEANFILES += config.sub
-MAINTAINERCLEANFILES += configure
-MAINTAINERCLEANFILES += Makefile.in
-MAINTAINERCLEANFILES += src/Makefile.in
-MAINTAINERCLEANFILES += test/Makefile.in
-MAINTAINERCLEANFILES += m4/libtool.m4
-MAINTAINERCLEANFILES += m4/ltoptions.m4
-MAINTAINERCLEANFILES += m4/ltsugar.m4
-MAINTAINERCLEANFILES += m4/ltversion.m4
-MAINTAINERCLEANFILES += m4/lt~obsolete.m4
+DISTCLEANFILES += src/utilities/include/timpi/timpi_config.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,6 +52,7 @@ if BUILD_PROF_MODE
   libtimpi_prof_la_SOURCES  = $(timpi_SOURCES)
   libtimpi_prof_la_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
   libtimpi_prof_la_CXXFLAGS = $(CXXFLAGS_PROF)
+  bin_PROGRAMS                += timpi_version-prof
 endif
 
 if BUILD_OPROF_MODE
@@ -59,6 +60,7 @@ if BUILD_OPROF_MODE
   libtimpi_oprof_la_SOURCES  = $(timpi_SOURCES)
   libtimpi_oprof_la_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
   libtimpi_oprof_la_CXXFLAGS = $(CXXFLAGS_OPROF)
+  bin_PROGRAMS                 += timpi_version-oprof
 endif
 
 
@@ -109,6 +111,12 @@ include_HEADERS += $(top_builddir)/src/utilities/include/timpi/timpi_config.h
 timpi_version_opt_SOURCES = apps/version.C
 timpi_version_opt_LDADD = libtimpi_opt.la
 
+timpi_version_oprof_SOURCES = apps/version.C
+timpi_version_oprof_LDADD = libtimpi_oprof.la
+
+timpi_version_prof_SOURCES = apps/version.C
+timpi_version_prof_LDADD = libtimpi_prof.la
+
 timpi_version_devel_SOURCES = apps/version.C
 timpi_version_devel_LDADD = libtimpi_devel.la
 
@@ -122,6 +130,6 @@ AM_CPPFLAGS  = $(timpi_optional_INCLUDES)
 AM_CPPFLAGS += -I$(top_srcdir)/src/algorithms/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/parallel/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/utilities/include
-AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #timpi_version.h
+AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #timpi_version.h, timpi_config.h
 
 LIBS         = $(timpi_optional_LIBS)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS  = $(timpi_optional_INCLUDES)
 AM_CPPFLAGS += -I$(top_srcdir)/src/algorithms/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/parallel/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/utilities/include
-AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #timpi_version.h
+AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #timpi_version.h, timpi_config.h
 
 LIBS         = $(timpi_optional_LIBS)
 


### PR DESCRIPTION
- Add */timpi_config.h to DISTCLEAN. I believe this actually caused
  me a nasty "bug" at one point where I was compiling TIMPI with
  a different config than what I was compiling a downstream app.
  Moreover, this meets the definition of a configure-generated file
  and hence should be included in `make distclean`. This is
  not currently caught by the default `make distclean` target
- Remove the MAINTAINERCLEANFILES targets. According to the automake
  manual: "maintainer-clean should not delete anything that needs to
  exist in order to run configure and make"
- Add prof and oprof targets for `timpi_version`