### PR TITLE
Create a Packing specialization for std::pair

### DIFF
--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -154,7 +154,10 @@ TIMPI_STANDARD_TYPE(long double,MPI_LONG_DOUBLE);
 #endif
 
 template<typename T1, typename T2>
-class StandardType<std::pair<T1, T2>> : public DataType
+class StandardType<std::pair<T1, T2>,
+                   typename std::enable_if<
+                     StandardType<T1>::is_fixed_type &&
+                     StandardType<T2>::is_fixed_type>::type> : public DataType
 {
 public:
   explicit
@@ -217,8 +220,7 @@ public:
 
   ~StandardType() { this->free(); }
 
-  static const bool is_fixed_type = StandardType<T1>::is_fixed_type
-    && StandardType<T2>::is_fixed_type;
+  static const bool is_fixed_type = true;
 };
 
 

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -112,6 +112,31 @@ Communicator *TestCommWorld;
     }
   }
 
+  void testPairContainerAllGather()
+  {
+    std::vector<std::pair<std::set<unsigned int>, unsigned int>> vals;
+    const unsigned int my_rank = TestCommWorld->rank();
+
+    std::vector<int> data_vec(my_rank + 1);
+    std::iota(data_vec.begin(), data_vec.end(), 0);
+    TestCommWorld->allgather(std::make_pair(
+                               std::set<unsigned int>(data_vec.begin(), data_vec.end()),
+                               my_rank), vals);
+
+    const std::size_t comm_size = TestCommWorld->size();
+    const std::size_t vec_size = vals.size();
+    TIMPI_UNIT_ASSERT(comm_size == vec_size);
+
+    for (std::size_t i = 0; i < vec_size; ++i)
+    {
+      const auto & current_set = vals[i].first;
+      unsigned int value = 0;
+      for (auto number : current_set)
+        TIMPI_UNIT_ASSERT(number == value++);
+      TIMPI_UNIT_ASSERT(vals[i].second == i);
+    }
+  }
+
   void testContainerBroadcast()
   {
     std::vector<std::set<unsigned int>> vals;
@@ -153,6 +178,7 @@ int main(int argc, const char * const * argv)
 
   testContainerAllGather();
   testContainerBroadcast();
+  testPairContainerAllGather();
 
   return 0;
 }


### PR DESCRIPTION
This specialization is enabled when the std::pair is not of fixed
size, e.g. when either first or second is not of fixed size.
Size of first and second are computed using sizeof when
one is of fixed size, and using Packing::*size when not of fixed
size. I also introduce a couple of helper structs in order to
"automatically" determine the buffer_type for the Packing<pair>
specialization