### PR TITLE
push_parallel_packed_range fixes and improvements

### DIFF
--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -169,8 +169,6 @@ void push_parallel_vector_data(const Communicator & comm,
   // without confusing one for the other
   auto tag = comm.get_unique_tag();
 
-  MapToVectors received_data;
-
   // Post all of the sends, non-blocking and synchronous
 
   // Save off the old send_mode so we can restore it after this
@@ -328,8 +326,6 @@ void push_parallel_packed_range(const Communicator & comm,
   // without confusing one for the other
   auto tag = comm.get_unique_tag();
 
-  MapToVectors received_data;
-
   // Post all of the sends, non-blocking and synchronous
 
   // Save off the old send_mode so we can restore it after this
@@ -481,7 +477,7 @@ void pull_parallel_vector_data(const Communicator & comm,
   typedef typename MapToVectors::mapped_type query_type;
 
   std::multimap<processor_id_type, std::vector<datum> >
-    response_data, received_data;
+    response_data;
 
 #ifndef NDEBUG
   processor_id_type max_pid = 0;

--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -371,7 +371,7 @@ void push_parallel_packed_range(const Communicator & comm,
   std::multimap<processor_id_type, std::shared_ptr<std::vector<nonconst_nonref_type>>> incoming_data;
   auto current_incoming_data = std::make_shared<std::vector<nonconst_nonref_type>>();
 
-  nonconst_nonref_type * output_type;
+  nonconst_nonref_type * output_type = nullptr;
 
   unsigned int current_src_proc = 0;
 

--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -304,11 +304,11 @@ void push_parallel_vector_data(const Communicator & comm,
 }
 
 
-template <typename MapToVectors,
+template <typename MapToContainers,
           typename ActionFunctor,
           typename Context>
 void push_parallel_packed_range(const Communicator & comm,
-                                const MapToVectors & data,
+                                const MapToContainers & data,
                                 Context * context,
                                 const ActionFunctor & act_on_data)
 {
@@ -318,8 +318,9 @@ void push_parallel_packed_range(const Communicator & comm,
   // This function implements the "NBX" algorithm from
   // https://htor.inf.ethz.ch/publications/img/hoefler-dsde-protocols.pdf
 
-  typedef decltype(data.begin()->second.front()) ref_type;
-  typedef typename std::remove_reference<ref_type>::type nonref_type;
+  typedef typename MapToContainers::value_type map_pair_type;
+  typedef typename map_pair_type::second_type container_type;
+  typedef typename container_type::value_type nonref_type;
   typedef typename std::remove_const<nonref_type>::type nonconst_nonref_type;
 
   // We'll grab a tag so we can overlap request sends and receives
@@ -368,8 +369,8 @@ void push_parallel_packed_range(const Communicator & comm,
   std::list<std::pair<unsigned int, std::shared_ptr<Request>>> receive_reqs;
   auto current_request = std::make_shared<Request>();
 
-  std::multimap<processor_id_type, std::shared_ptr<std::vector<nonconst_nonref_type>>> incoming_data;
-  auto current_incoming_data = std::make_shared<std::vector<nonconst_nonref_type>>();
+  std::multimap<processor_id_type, std::shared_ptr<container_type>> incoming_data;
+  auto current_incoming_data = std::make_shared<container_type>();
 
   nonconst_nonref_type * output_type = nullptr;
 
@@ -382,19 +383,18 @@ void push_parallel_packed_range(const Communicator & comm,
     current_src_proc = TIMPI::any_source;
 
     // Check if there is a message and start receiving it
-    if (comm.possibly_receive_packed_range(current_src_proc,
-                                           context,
-                                           std::back_inserter(*current_incoming_data),
-                                           output_type,
-                                           *current_request,
-                                           tag))
+    if (comm.possibly_receive_packed_range
+          (current_src_proc, context,
+           std::inserter(*current_incoming_data,
+                         current_incoming_data->end()),
+           output_type, *current_request, tag))
     {
       receive_reqs.emplace_back(current_src_proc, current_request);
       current_request = std::make_shared<Request>();
 
       // current_src_proc will now hold the src pid for this receive
       incoming_data.emplace(current_src_proc, current_incoming_data);
-      current_incoming_data = std::make_shared<std::vector<nonconst_nonref_type>>();
+      current_incoming_data = std::make_shared<container_type>();
     }
 
     // Clean up outstanding receive requests

--- a/src/parallel/include/timpi/packing.h
+++ b/src/parallel/include/timpi/packing.h
@@ -25,11 +25,11 @@
 #include "timpi/standard_type.h"
 
 // C++ includes
-#include <cstddef>
+#include <cstring>     // memcpy
 #include <iterator>
+#include <type_traits> // enable_if, is_same
+#include <utility>     // pair
 #include <vector>
-#include <utility>
-#include <cstring>
 
 
 // FIXME: This *should* be in TIMPI namespace but we have libMesh

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -257,8 +257,6 @@ inline Status Communicator::packed_range_probe (const unsigned int src_processor
 {
   TIMPI_LOG_SCOPE("packed_range_probe()", "Parallel");
 
-  timpi_experimental();
-
   Status stat((StandardType<typename Packing<T>::buffer_type>()));
 
   int int_flag;
@@ -737,8 +735,6 @@ inline void Communicator::nonblocking_send_packed_range (const unsigned int dest
                                                          Request & req,
                                                          const MessageTag & tag) const
 {
-  timpi_experimental();
-
   // Allocate a buffer on the heap so we don't have to free it until
   // after the Request::wait()
   typedef typename std::iterator_traits<Iter>::value_type T;
@@ -1201,8 +1197,6 @@ inline void Communicator::nonblocking_receive_packed_range (const unsigned int s
                                                             Status & stat,
                                                             const MessageTag & tag) const
 {
-  timpi_experimental();
-
   typedef typename Packing<T>::buffer_type buffer_t;
 
   // Receive serialized variable size objects as a sequence of
@@ -1421,8 +1415,6 @@ inline void Communicator::nonblocking_send_packed_range (const unsigned int dest
                                                          std::shared_ptr<std::vector<typename Packing<typename std::iterator_traits<Iter>::value_type>::buffer_type>> & buffer,
                                                          const MessageTag & tag) const
 {
-  timpi_experimental();
-
   // Allocate a buffer on the heap so we don't have to free it until
   // after the Request::wait()
   typedef typename std::iterator_traits<Iter>::value_type T;
@@ -2014,8 +2006,6 @@ inline void Communicator::nonblocking_receive_packed_range (const unsigned int s
                                                             std::shared_ptr<std::vector<typename Packing<T>::buffer_type>> & buffer,
                                                             const MessageTag & tag) const
 {
-  timpi_experimental();
-
   // If they didn't pass in a buffer - let's make one
   if (buffer == nullptr)
     buffer = std::make_shared<std::vector<typename Packing<T>::buffer_type>>();


### PR DESCRIPTION
This fixes the possibly-unused-variable warning that had my --enable-werror libMesh build screaming at me, along with some other fixes I saw along the way, a big expansion of compatibility with more container types, and a couple unit tests.

Haven't tested this with the fixed libMesh node constraints code yet, but I'll do that before I hit merge.