### PR TITLE
More dispatches to packed range; displace is_fixed_type idiom

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT(timpi, 1.2, roystgnr@ices.utexas.edu)
+AC_INIT(timpi, 1.2.0, roystgnr@ices.utexas.edu)
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_HEADER(src/utilities/include/timpi/timpi_config.h.tmp)

--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -162,6 +162,7 @@ void push_parallel_vector_data(const Communicator & comm,
   // This function must be run on all processors at once
   timpi_parallel_only(comm);
 
+#ifdef TIMPI_HAVE_MPI
   // This function implements the "NBX" algorithm from
   // https://htor.inf.ethz.ch/publications/img/hoefler-dsde-protocols.pdf
 
@@ -190,6 +191,7 @@ void push_parallel_vector_data(const Communicator & comm,
 
   // The send requests
   std::list<Request> reqs;
+#endif
 
   processor_id_type num_procs = comm.size();
 
@@ -205,9 +207,13 @@ void push_parallel_vector_data(const Communicator & comm,
         act_on_data(destid, datum);
       else
         {
+#ifdef TIMPI_HAVE_MPI
           Request sendreq;
           comm.send(destid, datum, type, sendreq, tag);
           reqs.push_back(sendreq);
+#else
+          timpi_error_msg("We should not be trying to send data without MPI");
+#endif
         }
     }
 
@@ -215,6 +221,7 @@ void push_parallel_vector_data(const Communicator & comm,
   if (comm.size() == 1)
     return;
 
+#ifdef TIMPI_HAVE_MPI
   bool sends_complete = reqs.empty();
   bool started_barrier = false;
   Request barrier_request;
@@ -313,6 +320,9 @@ void push_parallel_vector_data(const Communicator & comm,
 
   // Reset the send mode
   const_cast<Communicator &>(comm).send_mode(old_send_mode);
+#else
+  timpi_error_msg("We should not be trying to receive data without MPI");
+#endif
 }
 
 

--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -162,7 +162,6 @@ void push_parallel_vector_data(const Communicator & comm,
   // This function must be run on all processors at once
   timpi_parallel_only(comm);
 
-#ifdef TIMPI_HAVE_MPI
   // This function implements the "NBX" algorithm from
   // https://htor.inf.ethz.ch/publications/img/hoefler-dsde-protocols.pdf
 
@@ -191,7 +190,6 @@ void push_parallel_vector_data(const Communicator & comm,
 
   // The send requests
   std::list<Request> reqs;
-#endif
 
   processor_id_type num_procs = comm.size();
 
@@ -207,13 +205,9 @@ void push_parallel_vector_data(const Communicator & comm,
         act_on_data(destid, datum);
       else
         {
-#ifdef TIMPI_HAVE_MPI
           Request sendreq;
           comm.send(destid, datum, type, sendreq, tag);
           reqs.push_back(sendreq);
-#else
-          timpi_error_msg("We should not be trying to send data without MPI");
-#endif
         }
     }
 
@@ -221,7 +215,6 @@ void push_parallel_vector_data(const Communicator & comm,
   if (comm.size() == 1)
     return;
 
-#ifdef TIMPI_HAVE_MPI
   bool sends_complete = reqs.empty();
   bool started_barrier = false;
   Request barrier_request;
@@ -320,9 +313,6 @@ void push_parallel_vector_data(const Communicator & comm,
 
   // Reset the send mode
   const_cast<Communicator &>(comm).send_mode(old_send_mode);
-#else
-  timpi_error_msg("We should not be trying to receive data without MPI");
-#endif
 }
 
 

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -631,7 +631,7 @@ public:
   inline
   bool possibly_receive (unsigned int & src_processor_id,
                          std::vector<T,A> & buf,
-                         const DataType & type,
+                         const NotADataType & type,
                          Request & req,
                          const MessageTag & tag) const;
 

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -505,6 +505,18 @@ public:
              const MessageTag & tag=no_tag) const;
 
   /**
+   * Nonblocking-send to one processor with user-defined packable type.
+   * \p Packing<T> must be defined for \p T
+   */
+  template <typename T>
+  inline
+  void send (const unsigned int dest_processor_id,
+             const T & buf,
+             const NotADataType & type,
+             Request & req,
+             const MessageTag & tag=no_tag) const;
+
+  /**
    * Blocking-receive from one processor with data-defined type.
    */
   template <typename T>

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -607,7 +607,27 @@ public:
    * @param tag The tag to use
 
    */
-  template <typename T, typename A>
+  template <typename T, typename A, typename std::enable_if<StandardType<T>::is_fixed_type, int>::type = 0>
+  inline
+  bool possibly_receive (unsigned int & src_processor_id,
+                         std::vector<T,A> & buf,
+                         const DataType & type,
+                         Request & req,
+                         const MessageTag & tag) const;
+
+  /**
+   * Nonblocking-receive from one processor with user-defined type. Dispatches to \p
+   * possibly_receive_packed_range
+   *
+   * @param src_processor_id The pid to receive from or "any".
+   * will be set to the actual src being received from
+   * @param buf The buffer to receive into
+   * @param type The intrinsic datatype to receive
+   * @param req The request to use
+   * @param tag The tag to use
+
+   */
+  template <typename T, typename A, typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type = 0>
   inline
   bool possibly_receive (unsigned int & src_processor_id,
                          std::vector<T,A> & buf,

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -623,7 +623,7 @@ public:
    * @param src_processor_id The pid to receive from or "any".
    * will be set to the actual src being received from
    * @param buf The buffer to receive into
-   * @param type The intrinsic datatype to receive
+   * @param type The packable type to receive
    * @param req The request to use
    * @param tag The tag to use
 

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -240,8 +240,8 @@ private:
    * by broadcasting pairs
    */
   template <typename Map,
-            typename std::enable_if<Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                    Has_datatype<StandardType<typename Map::mapped_type>>::value,
+            typename std::enable_if<std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                    std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value,
                                     int>::type = 0>
   void map_sum(Map & data) const;
 
@@ -251,8 +251,8 @@ private:
    * twice: once for the keys and once for the values.
    */
   template <typename Map,
-            typename std::enable_if<!(Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                      Has_datatype<StandardType<typename Map::mapped_type>>::value),
+            typename std::enable_if<!(std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                      std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value),
                                     int>::type = 0>
   void map_sum(Map & data) const;
 
@@ -261,8 +261,8 @@ private:
    * specializations. This is_fixed_type variant saves a communication by broadcasting pairs
    */
   template <typename Map,
-            typename std::enable_if<Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                    Has_datatype<StandardType<typename Map::mapped_type>>::value,
+            typename std::enable_if<std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                    std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value,
                                     int>::type = 0>
   void map_broadcast(Map & data,
                      const unsigned int root_id,
@@ -275,8 +275,8 @@ private:
    * key_type or mapped_type)
    */
   template <typename Map,
-            typename std::enable_if<!(Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                      Has_datatype<StandardType<typename Map::mapped_type>>::value),
+            typename std::enable_if<!(std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                      std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value),
                                     int>::type = 0>
   void map_broadcast(Map & data,
                      const unsigned int root_id,
@@ -288,8 +288,8 @@ private:
    * communication by broadcasting pairs
    */
   template <typename Map,
-            typename std::enable_if<Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                    Has_datatype<StandardType<typename Map::mapped_type>>::value,
+            typename std::enable_if<std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                    std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value,
                                     int>::type = 0>
   void map_max(Map & data) const;
 
@@ -299,8 +299,8 @@ private:
    * twice: once for the keys and once for the values.
    */
   template <typename Map,
-            typename std::enable_if<!(Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                      Has_datatype<StandardType<typename Map::mapped_type>>::value),
+            typename std::enable_if<!(std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                      std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value),
                                     int>::type = 0>
   void map_max(Map & data) const;
 
@@ -571,7 +571,7 @@ public:
    * @param tag The tag to use
    */
   template <typename T, typename A,
-            typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+            typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
   inline
   bool possibly_receive (unsigned int & src_processor_id,
                          std::vector<T,A> & buf,
@@ -608,7 +608,7 @@ public:
    * @param tag The tag to use
 
    */
-  template <typename T, typename A, typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+  template <typename T, typename A, typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
   inline
   bool possibly_receive (unsigned int & src_processor_id,
                          std::vector<T,A> & buf,
@@ -972,7 +972,7 @@ public:
    * \p recv[processor_id] = the value of \p send on that processor. This
    * overload works on fixed size types
    */
-  template <typename T, typename A, typename std::enable_if<Has_datatype<StandardType<T>>::value,
+  template <typename T, typename A, typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value,
                                                             int>::type = 0>
   inline void allgather(const T & send,
                         std::vector<T,A> & recv) const;
@@ -1023,7 +1023,7 @@ public:
    * must be called by all processors in the Communicator.
    */
   template <typename T, typename A,
-            typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+            typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
   inline void allgather(std::vector<T,A> & r,
                         const bool identical_buffer_sizes = false) const;
 
@@ -1173,7 +1173,7 @@ public:
    * Fixed variant
    */
   template <typename T,
-            typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+            typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
   inline void broadcast(T & data, const unsigned int root_id=0,
                         const bool identical_sizes=false) const;
 

--- a/src/parallel/include/timpi/data_type.h
+++ b/src/parallel/include/timpi/data_type.h
@@ -105,26 +105,6 @@ protected:
   data_type _datatype;
 };
 
-// Idiom taken from https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector
-template < class T >
-class Has_datatype
-{
-private:
-    using Yes = char[2];
-    using  No = char[1];
-
-    struct Fallback { struct _datatype { }; };
-    struct Derived : T, Fallback { };
-
-    template < class U >
-    static No& test ( typename U::_datatype* );
-    template < typename U >
-    static Yes& test ( U* );
-
-public:
-    static constexpr bool value = sizeof(test<Derived>(nullptr)) == sizeof(Yes);
-};
-
 class NotADataType
 {
 public:

--- a/src/parallel/include/timpi/data_type.h
+++ b/src/parallel/include/timpi/data_type.h
@@ -105,6 +105,26 @@ protected:
   data_type _datatype;
 };
 
+// Idiom taken from https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector
+template < class T >
+class Has_datatype
+{
+private:
+    using Yes = char[2];
+    using  No = char[1];
+
+    struct Fallback { struct _datatype { }; };
+    struct Derived : T, Fallback { };
+
+    template < class U >
+    static No& test ( typename U::_datatype* );
+    template < typename U >
+    static Yes& test ( U* );
+
+public:
+    static constexpr bool value = sizeof(test<Derived>(nullptr)) == sizeof(Yes);
+};
+
 class NotADataType
 {
 public:

--- a/src/parallel/include/timpi/data_type.h
+++ b/src/parallel/include/timpi/data_type.h
@@ -105,6 +105,18 @@ protected:
   data_type _datatype;
 };
 
+/**
+ * StandardType<T>'s which do not define a way to \p MPI_Type \p T should
+ * inherit from this class. This class is primarily defined for backwards
+ * compatability because it defines \p is_fixed_type = false for
+ * non-fixed/non-mpi-typed StandardTypes. This class also provides a fairly
+ * convenient way to define communication overloads that are antithetical to \p
+ * DataType counterparts. E.g. when doing our parallel algorithms we may build a
+ * \p StandardType and then call communication routines with that type. We want
+ * to ensure that we dispatch to different methods when \p StandardType defines
+ * MPI typing vs. when it does not. The \p DataType vs. \p NotADataType typing
+ * accomplishes that goal
+ */
 class NotADataType
 {
 public:

--- a/src/parallel/include/timpi/data_type.h
+++ b/src/parallel/include/timpi/data_type.h
@@ -53,6 +53,7 @@ public:
   DataType () = default;
   DataType (const DataType & other) = default;
   DataType (DataType && other) = default;
+  static const bool is_fixed_type = true;
 
   DataType (const data_type & type) :
     _datatype(type)
@@ -102,6 +103,30 @@ public:
 protected:
 
   data_type _datatype;
+};
+
+class NotADataType
+{
+public:
+  NotADataType () = default;
+  NotADataType (const NotADataType & other) = default;
+  NotADataType (NotADataType && other) = default;
+  ~NotADataType () = default;
+  NotADataType & operator = (const NotADataType & other) = default;
+  NotADataType & operator = (NotADataType && other) = default;
+
+  static const bool is_fixed_type = false;
+};
+
+template <bool>
+struct MaybeADataType {
+  typedef DataType type;
+};
+
+template <>
+struct MaybeADataType<false>
+{
+  typedef NotADataType type;
 };
 
 } // namespace TIMPI

--- a/src/parallel/include/timpi/packing.h
+++ b/src/parallel/include/timpi/packing.h
@@ -389,7 +389,7 @@ inline Iter pack_range (const Context * context,
 #endif
 
       Packing<T>::pack
-        (*range_begin, back_inserter(buffer), context);
+        (*range_begin, std::back_inserter(buffer), context);
 
 #ifndef NDEBUG
       unsigned int my_packable_size =

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -123,6 +123,40 @@
                            Request & req,
                            const MessageTag & tag) const;
 
+    template <typename T, typename A1, typename A2>
+    inline
+    bool possibly_receive (unsigned int & src_processor_id,
+                           std::vector<std::vector<T,A1>,A2> & buf,
+                           const DataType & type,
+                           Request & req,
+                           const MessageTag & tag) const;
+
+    template <typename T, typename A,
+              typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+    inline
+    void broadcast(std::vector<T,A> &data,
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
+
+    template <typename T, typename A,
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
+    inline
+    void broadcast(std::vector<T,A> &data,
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
+
+    template <typename T1, typename T2, typename C, typename A>
+    inline
+    void broadcast(std::map<T1,T2,C,A> &data,
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
+
+    template <typename K, typename V, typename H, typename E, typename A>
+    inline
+    void broadcast(std::unordered_map<K,V,H,E,A> &data,
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
+
 // We only need to bother with many of these specializations if we're
 // actually in parallel.
 #ifdef TIMPI_HAVE_MPI
@@ -174,7 +208,7 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<StandardType<T>::is_fixed_type, int>::type = 0>
+              typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
@@ -182,7 +216,7 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type = 0>
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
@@ -197,7 +231,7 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<StandardType<T>::is_fixed_type, int>::type = 0>
+              typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
@@ -206,7 +240,7 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type = 0>
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
@@ -333,37 +367,20 @@
 
     template <typename T, typename A1, typename A2>
     inline
-    bool possibly_receive (unsigned int & src_processor_id,
-                           std::vector<std::vector<T,A1>,A2> & buf,
-                           const DataType & type,
-                           Request & req,
-                           const MessageTag & tag) const;
-
-    template <typename T, typename A1, typename A2>
-    inline
     void receive (const unsigned int src_processor_id,
                   std::vector<std::vector<T,A1>,A2> &buf,
                   const DataType &type,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
 
+    inline
+    void broadcast(bool & data,
+                   const unsigned int root_id=0,
+                   const bool identical_sizes=false) const;
+
     template <typename T>
     inline
     void broadcast(std::basic_string<T> &data,
-                   const unsigned int root_id=0,
-                   const bool identical_sizes=false) const;
-
-    template <typename T, typename A,
-              typename std::enable_if<StandardType<T>::is_fixed_type, int>::type = 0>
-    inline
-    void broadcast(std::vector<T,A> &data,
-                   const unsigned int root_id=0,
-                   const bool identical_sizes=false) const;
-
-    template <typename T, typename A,
-              typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type = 0>
-    inline
-    void broadcast(std::vector<T,A> &data,
                    const unsigned int root_id=0,
                    const bool identical_sizes=false) const;
 
@@ -385,17 +402,6 @@
                    const unsigned int root_id=0,
                    const bool identical_sizes=false) const;
 
-    template <typename T1, typename T2, typename C, typename A>
-    inline
-    void broadcast(std::map<T1,T2,C,A> &data,
-                   const unsigned int root_id=0,
-                   const bool identical_sizes=false) const;
-
-    template <typename K, typename V, typename H, typename E, typename A>
-    inline
-    void broadcast(std::unordered_map<K,V,H,E,A> &data,
-                   const unsigned int root_id=0,
-                   const bool identical_sizes=false) const;
 
     // In new overloaded function template entries we have to
     // re-specify the default arguments

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -210,7 +210,7 @@
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
-               const DataType &type,
+               const NotADataType &type,
                Request &req,
                const MessageTag &tag=no_tag) const;
 

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -173,7 +173,16 @@
                const std::vector<T,A> & buf,
                const MessageTag &tag=no_tag) const;
 
-    template <typename T, typename A>
+    template <typename T, typename A,
+              typename std::enable_if<StandardType<T>::is_fixed_type, int>::type = 0>
+    inline
+    void send (const unsigned int dest_processor_id,
+               const std::vector<T,A> & buf,
+               Request &req,
+               const MessageTag &tag=no_tag) const;
+
+    template <typename T, typename A,
+              typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -196,7 +196,17 @@
                const DataType &type,
                const MessageTag &tag=no_tag) const;
 
-    template <typename T, typename A>
+    template <typename T, typename A,
+              typename std::enable_if<StandardType<T>::is_fixed_type, int>::type = 0>
+    inline
+    void send (const unsigned int dest_processor_id,
+               const std::vector<T,A> & buf,
+               const DataType &type,
+               Request &req,
+               const MessageTag &tag=no_tag) const;
+
+    template <typename T, typename A,
+              typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -132,7 +132,7 @@
                            const MessageTag & tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+              typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
     inline
     void broadcast(std::vector<T,A> &data,
                    const unsigned int root_id=0,
@@ -208,7 +208,7 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+              typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
@@ -231,7 +231,7 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A,
-              typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type = 0>
+              typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
     inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -505,7 +505,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 template <typename T, typename A, typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type>
 inline void Communicator::send (const unsigned int dest_processor_id,
                                 const std::vector<T,A> & buf,
-                                const DataType &,
+                                const NotADataType &,
                                 Request & req,
                                 const MessageTag & tag) const
 {
@@ -2047,7 +2047,7 @@ inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
 template <typename T, typename A, typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type>
 inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
                                             std::vector<T,A> & buf,
-                                            const DataType &,
+                                            const NotADataType &,
                                             Request & req,
                                             const MessageTag & tag) const
 {

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -2867,10 +2867,9 @@ inline void Communicator::allgather(std::vector<T,A> & r,
 
   if (identical_buffer_sizes)
     {
+      timpi_assert(this->verify(r.size()));
       if (r.empty())
         return;
-
-      timpi_assert(this->verify(r.size()));
 
       std::vector<T,A> r_src(r.size()*this->size());
       r_src.swap(r);
@@ -2930,10 +2929,10 @@ inline void Communicator::allgather(std::vector<T,A> & r,
 
   if (identical_buffer_sizes)
     {
+      timpi_assert(this->verify(r.size()));
       if (r.empty())
         return;
 
-      timpi_assert(this->verify(r.size()));
 
       std::vector<T,A> r_src(r.size()*this->size());
       r_src.swap(r);

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -430,7 +430,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
 
 template <typename T, typename A,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline void Communicator::send (const unsigned int dest_processor_id,
                                 const std::vector<T,A> & buf,
                                 Request & req,
@@ -476,7 +476,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
 
 
-template <typename T, typename A, typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+template <typename T, typename A, typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline void Communicator::send (const unsigned int dest_processor_id,
                                 const std::vector<T,A> & buf,
                                 const DataType & type,
@@ -1802,7 +1802,7 @@ inline void Communicator::nonblocking_receive_packed_range (const unsigned int s
 
 
 
-template <typename T, typename A, typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+template <typename T, typename A, typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
                                             std::vector<T,A> & buf,
                                             const DataType & type,
@@ -2230,8 +2230,8 @@ inline void Communicator::max(std::vector<bool,A> & r) const
 
 
 template <typename Map,
-          typename std::enable_if<Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                  Has_datatype<StandardType<typename Map::mapped_type>>::value,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                  std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value,
                                   int>::type>
 void Communicator::map_max(Map & data) const
 {
@@ -2273,8 +2273,8 @@ void Communicator::map_max(Map & data) const
 
 
 template <typename Map,
-          typename std::enable_if<!(Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                    Has_datatype<StandardType<typename Map::mapped_type>>::value),
+          typename std::enable_if<!(std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                    std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value),
                                   int>::type>
 void Communicator::map_max(Map & data) const
 {
@@ -2519,8 +2519,8 @@ inline void Communicator::sum(std::vector<std::complex<T>,A> & r) const
 // Helper function for summing std::map and std::unordered_map with
 // fixed type (key, value) pairs.
 template <typename Map,
-          typename std::enable_if<Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                  Has_datatype<StandardType<typename Map::mapped_type>>::value,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                  std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value,
                                   int>::type>
 inline void Communicator::map_sum(Map & data) const
 {
@@ -2551,8 +2551,8 @@ inline void Communicator::map_sum(Map & data) const
 // Helper function for summing std::map and std::unordered_map with
 // non-fixed-type (key, value) pairs.
 template <typename Map,
-          typename std::enable_if<!(Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                    Has_datatype<StandardType<typename Map::mapped_type>>::value),
+          typename std::enable_if<!(std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                    std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value),
                                   int>::type>
 inline void Communicator::map_sum(Map & data) const
 {
@@ -2807,7 +2807,7 @@ inline void Communicator::gather(const unsigned int root_id,
 
 
 template <typename T, typename A,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline void Communicator::allgather(const T & sendval,
                                     std::vector<T,A> & recv) const
 {
@@ -2856,7 +2856,7 @@ inline void Communicator::allgather(const T & sendval,
 }
 
 template <typename T, typename A,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline void Communicator::allgather(std::vector<T,A> & r,
                                     const bool identical_buffer_sizes) const
 {
@@ -3264,7 +3264,7 @@ inline void Communicator::alltoall(std::vector<T,A> & buf) const
 
 
 template <typename T,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline void Communicator::broadcast (T & timpi_mpi_var(data),
                                      const unsigned int root_id,
                                      const bool /* identical_sizes */) const
@@ -3323,7 +3323,7 @@ inline void Communicator::broadcast (T & data,
 }
 
 template <typename T, typename A,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline void Communicator::broadcast (std::vector<T,A> & timpi_mpi_var(data),
                                      const unsigned int root_id,
                                      const bool timpi_mpi_var(identical_sizes)) const
@@ -3402,8 +3402,8 @@ inline void Communicator::broadcast (std::vector<T,A> & data,
 }
 
 template <typename Map,
-          typename std::enable_if<Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                  Has_datatype<StandardType<typename Map::mapped_type>>::value,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                  std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value,
                                   int>::type>
 inline void Communicator::map_broadcast(Map & timpi_mpi_var(data),
                                         const unsigned int root_id,
@@ -3448,8 +3448,8 @@ inline void Communicator::map_broadcast(Map & timpi_mpi_var(data),
 }
 
 template <typename Map,
-          typename std::enable_if<!(Has_datatype<StandardType<typename Map::key_type>>::value &&
-                                    Has_datatype<StandardType<typename Map::mapped_type>>::value),
+          typename std::enable_if<!(std::is_base_of<DataType, StandardType<typename Map::key_type>>::value &&
+                                    std::is_base_of<DataType, StandardType<typename Map::mapped_type>>::value),
                                   int>::type>
 inline void Communicator::map_broadcast(Map & timpi_mpi_var(data),
                                         const unsigned int root_id,
@@ -3679,7 +3679,7 @@ inline Status Communicator::packed_range_probe (const unsigned int src_processor
 
 
 template <typename T, typename A,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
                                             std::vector<T,A> & buf,
                                             Request & req,

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -1965,52 +1965,6 @@ inline void Communicator::broadcast(std::unordered_map<K,V,H,E,A> & data,
 }
 
 
-
-template <typename Context, typename OutputContext,
-          typename Iter, typename OutputIter>
-inline void Communicator::broadcast_packed_range(const Context * context1,
-                                                 Iter range_begin,
-                                                 const Iter range_end,
-                                                 OutputContext * context2,
-                                                 OutputIter out_iter,
-                                                 const unsigned int root_id,
-                                                 std::size_t approx_buffer_size) const
-{
-  typedef typename std::iterator_traits<Iter>::value_type T;
-  typedef typename Packing<T>::buffer_type buffer_t;
-
-  do
-    {
-      // We will serialize variable size objects from *range_begin to
-      // *range_end as a sequence of ints in this buffer
-      std::vector<buffer_t> buffer;
-
-      if (this->rank() == root_id)
-        range_begin = pack_range
-          (context1, range_begin, range_end, buffer, approx_buffer_size);
-
-      // this->broadcast(vector) requires the receiving vectors to
-      // already be the appropriate size
-      std::size_t buffer_size = buffer.size();
-      this->broadcast (buffer_size, root_id);
-
-      // We continue until there's nothing left to broadcast
-      if (!buffer_size)
-        break;
-
-      buffer.resize(buffer_size);
-
-      // Broadcast the packed data
-      this->broadcast (buffer, root_id);
-
-      if (this->rank() != root_id)
-        unpack_range
-          (buffer, context2, out_iter, (T*)nullptr);
-    } while (true);  // break above when we reach buffer_size==0
-}
-
-
-
 template <typename Context, typename OutputIter, typename T>
 inline void Communicator::nonblocking_receive_packed_range (const unsigned int src_processor_id,
                                                             Context * context,
@@ -3532,7 +3486,7 @@ inline void Communicator::broadcast (T & timpi_mpi_var(data),
 
 template <typename T,
           typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type>
-inline void Communicator::broadcast (T & data,
+inline void Communicator::broadcast (T & timpi_mpi_var(data),
                                      const unsigned int root_id,
                                      const bool /* identical_sizes */) const
 {
@@ -3546,6 +3500,12 @@ inline void Communicator::broadcast (T & data,
 
   timpi_assert_less (root_id, this->size());
 
+  // If we don't have MPI, then we should be done, and calling the below can
+  // have the side effect of instantiating Packing<T> classes that are not
+  // defined. (Normally we would be calling a more specialized overload of
+  // broacast that would then call broadcast_packed_range with appropriate
+  // template arguments)
+#ifdef TIMPI_HAVE_MPI
   std::vector<T> range = {data};
 
   this->broadcast_packed_range((void *)(nullptr),
@@ -3556,8 +3516,58 @@ inline void Communicator::broadcast (T & data,
                                root_id);
 
   data = range[0];
+#endif
 }
 
+template <typename Context, typename OutputContext,
+          typename Iter, typename OutputIter>
+inline void Communicator::broadcast_packed_range(const Context * context1,
+                                                 Iter range_begin,
+                                                 const Iter range_end,
+                                                 OutputContext * context2,
+                                                 OutputIter out_iter,
+                                                 const unsigned int root_id,
+                                                 std::size_t approx_buffer_size) const
+{
+  typedef typename std::iterator_traits<Iter>::value_type T;
+  typedef typename Packing<T>::buffer_type buffer_t;
+
+  if (this->size() == 1)
+  {
+    timpi_assert (!this->rank());
+    timpi_assert (!root_id);
+    return;
+  }
+
+  do
+  {
+    // We will serialize variable size objects from *range_begin to
+    // *range_end as a sequence of ints in this buffer
+    std::vector<buffer_t> buffer;
+
+    if (this->rank() == root_id)
+      range_begin = pack_range
+        (context1, range_begin, range_end, buffer, approx_buffer_size);
+
+    // this->broadcast(vector) requires the receiving vectors to
+    // already be the appropriate size
+    std::size_t buffer_size = buffer.size();
+    this->broadcast (buffer_size, root_id);
+
+    // We continue until there's nothing left to broadcast
+    if (!buffer_size)
+      break;
+
+    buffer.resize(buffer_size);
+
+    // Broadcast the packed data
+    this->broadcast (buffer, root_id);
+
+    if (this->rank() != root_id)
+      unpack_range
+        (buffer, context2, out_iter, (T*)nullptr);
+  } while (true);  // break above when we reach buffer_size==0
+}
 
 
 template <typename Context, typename Iter, typename OutputIter>

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -257,7 +257,7 @@ template <typename T, typename A,
           typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type>
 inline bool Communicator::possibly_receive (unsigned int &,
                                             std::vector<T,A> &,
-                                            const DataType &,
+                                            const NotADataType &,
                                             Request &,
                                             const MessageTag &) const
 {

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -241,7 +241,20 @@ Communicator::send_receive_packed_range
 
 
 
-template <typename T, typename A>
+template <typename T, typename A,
+          typename std::enable_if<StandardType<T>::is_fixed_type, int>::type>
+inline bool Communicator::possibly_receive (unsigned int &,
+                                            std::vector<T,A> &,
+                                            const DataType &,
+                                            Request &,
+                                            const MessageTag &) const
+{
+  // Non-blocking I/O from self to self?
+  timpi_not_implemented();
+}
+
+template <typename T, typename A,
+          typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type>
 inline bool Communicator::possibly_receive (unsigned int &,
                                             std::vector<T,A> &,
                                             const DataType &,

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -89,6 +89,14 @@ inline void Communicator::send (const unsigned int,
                                 const MessageTag &) const
 { timpi_not_implemented(); }
 
+template <typename T>
+inline void Communicator::send (const unsigned int,
+                                const T &,
+                                const NotADataType &,
+                                Request &,
+                                const MessageTag &) const
+{ timpi_not_implemented(); }
+
 template <typename Context, typename Iter>
 inline void Communicator::send_packed_range(const unsigned int,
                                             const Context *,

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -242,7 +242,7 @@ Communicator::send_receive_packed_range
 
 
 template <typename T, typename A,
-          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
 inline bool Communicator::possibly_receive (unsigned int &,
                                             std::vector<T,A> &,
                                             const DataType &,

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -242,7 +242,7 @@ Communicator::send_receive_packed_range
 
 
 template <typename T, typename A,
-          typename std::enable_if<StandardType<T>::is_fixed_type, int>::type>
+          typename std::enable_if<Has_datatype<StandardType<T>>::value, int>::type>
 inline bool Communicator::possibly_receive (unsigned int &,
                                             std::vector<T,A> &,
                                             const DataType &,
@@ -254,7 +254,7 @@ inline bool Communicator::possibly_receive (unsigned int &,
 }
 
 template <typename T, typename A,
-          typename std::enable_if<!StandardType<T>::is_fixed_type, int>::type>
+          typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type>
 inline bool Communicator::possibly_receive (unsigned int &,
                                             std::vector<T,A> &,
                                             const NotADataType &,
@@ -265,6 +265,17 @@ inline bool Communicator::possibly_receive (unsigned int &,
   timpi_not_implemented();
 }
 
+template <typename T, typename A1, typename A2>
+inline
+bool Communicator::possibly_receive (unsigned int &,
+                                     std::vector<std::vector<T,A1>,A2> &,
+                                     const DataType &,
+                                     Request &,
+                                     const MessageTag &) const
+{
+  // Non-blocking I/O from self to self?
+  timpi_not_implemented();
+}
 
 } // namespace TIMPI
 

--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -50,8 +50,19 @@ struct standardtype_dependent_false : std::false_type
 {};
 
 /**
- * Templated class to provide the appropriate MPI datatype
- * for use with built-in C types or simple C++ constructions.
+ * Templated class to provide the appropriate MPI datatype for use with built-in
+ * C types or simple C++ constructions. Note that the unspecialized class
+ * inherits from \p NotADataType. Users defining their own \p StandardType and
+ * defining their own MPI dataype will want to inherit from \p DataType, which
+ * includes an \p MPI_Datatype member (when we have MPI). A user <em>may
+ * also</em> want to define a \p StandardType that inherits from \p NotADataType
+ * if they are defining a \p Packing specialization for the same type \p T. This
+ * will enable them to call non-packed-range code with their dynamically sized
+ * data and have automatic dispatch to packed range methods when required. Note
+ * that a user wishing to make use of automatic dispatch to packed range methods
+ * will need to define a public constructor in order for their code to
+ * compile. Normal MPI-typeable \p StandardType specializations will obviously
+ * need to also define public constructors.
  *
  * More complicated data types may need to provide a pointer-to-T so
  * that we can use MPI_Address without constructing a new T.

--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -57,11 +57,8 @@ struct standardtype_dependent_false : std::false_type
  * that we can use MPI_Address without constructing a new T.
  */
 template <typename T, typename Enable = void>
-class StandardType : public DataType
+class StandardType : public NotADataType
 {
-public:
-  static const bool is_fixed_type = false;
-
   /*
    * The unspecialized class is useless, so we make its constructor
    * private to catch mistakes at compile-time rather than link-time.

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -19,8 +19,9 @@ class StandardType<std::set<T>> : public DataType
 public:
   static const bool is_fixed_type = false;
 
-private:
-  StandardType(const std::set<T> * example = nullptr);
+  StandardType(const std::set<T> *) : DataType()
+    {
+    }
 };
 }
 
@@ -217,7 +218,7 @@ std::set<T> createSet(std::size_t size)
 
     // Test the received results, for each processor id p we're in
     // charge of.
-    for (int p=rank; p != size; p += size)
+    for (int p=rank; p < size; p += size)
       for (int srcp=0; srcp != size; ++srcp)
         {
           // The source processor should be a key in the map
@@ -259,14 +260,6 @@ int main(int argc, const char * const * argv)
   testContainerAllGather();
   testContainerBroadcast();
   testPairContainerAllGather();
-
-  volatile int i = 0;
-  char hostname[256];
-  gethostname(hostname, sizeof(hostname));
-  printf("PID %d on %s ready for attach\n", getpid(), hostname);
-  fflush(stdout);
-  while (0 == i)
-    sleep(5);
 
   testPush();
 

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -14,19 +14,12 @@
 namespace TIMPI
 {
 template <typename T>
-class StandardType<std::set<T>> : public DataType
+class StandardType<std::set<T>> : public NotADataType
 {
 public:
-  static const bool is_fixed_type = false;
-
-#ifdef TIMPI_HAVE_MPI
-  StandardType(const std::set<T> *) : DataType(StandardType<typename InnermostType<T>::type>{})
+  StandardType(const std::set<T> *)
     {
     }
-#else
-  StandardType(const std::set<T> *) : DataType() {}
-#endif
-
 };
 }
 

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -19,9 +19,14 @@ class StandardType<std::set<T>> : public DataType
 public:
   static const bool is_fixed_type = false;
 
-  StandardType(const std::set<T> *) : DataType()
+#ifdef TIMPI_HAVE_MPI
+  StandardType(const std::set<T> *) : DataType(StandardType<typename InnermostType<T>::type>{})
     {
     }
+#else
+  StandardType(const std::set<T> *) : DataType() {}
+#endif
+
 };
 }
 


### PR DESCRIPTION
@roystgnr has expressed his dislike of the `is_fixed_type` idiom, and I
never loved it either. So let's use the member detector idioms
that are already well known in C++. Something should be sendable
using MPI_Datatype if the `StandardType<T>` specialization inherits
from `Datatype` which has the `_datatype` member indicating an
MPI_Datatype. This kind of thinking requires that `StandardType`
specializations which are not sendable via `MPI_Datatype` **do not**
inherit from `Datatype`. Removing that inheritance also makes it impossible
to call a `Communicator` API that takes a `TIMPI::Datatype` with an object that actually doesn't
support sending via `MPI_Datatype`.

Moreover, I don't think we should enable templates just because something
**is not** true. We should only emplate templates when something **is**
true. So now `MPI_Datatype` APIs are enabled if `Has_datatype` is `true`.
And packed-range dispatching APIs are enabled if `Has_buffer_type` is
`true`.

I've moved quite a few methods out of the `#ifdef TIMPI_HAVE_MPI`
section of `parallel_implementation.h` if they present easy return
opportunities when `comm.size() == 1`. I actually had to do this
because my decision to get rid of enabling of templates based on something
not being `true` actually made it so that there were no viable template
candidates in many of our test cases. I actually found that encouraging.
We should not be falling into an overload by accident.