### PR TITLE
Cache StandardType in push_parallel_vector_data

### DIFF
--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -169,8 +169,11 @@ void push_parallel_vector_data(const Communicator & comm,
   // without confusing one for the other
   auto tag = comm.get_unique_tag();
 
-  // We'll construct the StandardType once rather than inside a loop
-  auto type = build_standard_type(&data.begin()->second);
+  // We'll construct the StandardType once rather than inside a loop.
+  // We can't pass in example data here, because we might have
+  // data.empty() on some ranks, so we'll need StandardType to be able
+  // to construct the user's data type without an example.
+  auto type = build_standard_type(static_cast<nonconst_nonref_type*>(nullptr));
 
   // Post all of the sends, non-blocking and synchronous
 

--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -73,6 +73,49 @@ private:
 };
 
 
+/*
+ * Template metaprogramming to make build_standard_type work nicely
+ * with nested containers
+ */
+template <typename T>
+struct InnermostType
+{
+  typedef T type;
+};
+
+
+template <typename T>
+struct InnermostType<std::vector<T>>
+{
+  typedef typename InnermostType<T>::type type;
+};
+
+
+/*
+ * Returns a StandardType suitable for use with the example data.
+ */
+template <typename T>
+StandardType<T> build_standard_type(const T * example = nullptr)
+{
+  StandardType<T> returnval(example);
+  return returnval;
+}
+
+
+
+/*
+ * Returns a StandardType suitable for use with the data in the
+ * example container.
+ */
+template <typename T>
+StandardType<typename InnermostType<T>::type>
+build_standard_type(const std::vector<T> * example = nullptr)
+{
+  const T * inner_example = (example && !example->empty()) ? &(*example)[0] : nullptr;
+  return build_standard_type(inner_example);
+}
+
+
 
 // ------------------------------------------------------------
 // Declare StandardType specializations for C++ built-in types


### PR DESCRIPTION
This avoids destroying and reallocating a StandardType on each NBX loop, which was taking up a ton of time in some of our profiling.  Fingers crossed, this might fix a recent performance regression *and* further improve a recent performance optimization.

On the other hand, with this change we may just end up busy looping more often, rather than actually finishing communications faster.

@fdkong, could you try this out on the same problem you've been profiling for me?  I'd love to see how the gperftools output changes.