### PR TITLE
Directly include header files in parallel_sync.h

### DIFF
--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -24,10 +24,14 @@
 #include "timpi/parallel_implementation.h"
 
 // C++ includes
-#include <map>
-#include <type_traits>
-#include <vector>
+#include <algorithm>   // max
+#include <iterator>    // inserter
 #include <list>
+#include <map>         // map, multimap, pair
+#include <memory>      // shared_ptr, make_shared
+#include <type_traits> // remove_reference, remove_const
+#include <utility>     // move
+#include <vector>
 
 
 namespace TIMPI {


### PR DESCRIPTION
@jwpeterson pointed out to me that we're relying heavily here on a lot
of indirect inclusions via parallel_implementation.h