### PR TITLE
Add -Wcast-align to clang ignore_warnings.h

### DIFF
--- a/src/utilities/include/timpi/ignore_warnings.h
+++ b/src/utilities/include/timpi/ignore_warnings.h
@@ -33,6 +33,7 @@
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #pragma clang diagnostic ignored "-Wextra"
 #pragma clang diagnostic ignored "-Wredundant-decls"
+#pragma clang diagnostic ignored "-Wcast-align"
 #pragma clang diagnostic ignored "-Wcast-qual"
 #pragma clang diagnostic ignored "-Wswitch-default"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Not sure this is the safest warning to ignore, but it's triggering on
Ubuntu OpenMPI's mpi.h for me.