### PR TITLE
Ensure methods with SFINAE abling can be used in serial

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT(timpi, 1.3, roystgnr@ices.utexas.edu)
+AC_INIT(timpi, 1.3.0, roystgnr@ices.utexas.edu)
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_HEADER(src/utilities/include/timpi/timpi_config.h.tmp)

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -1208,11 +1208,16 @@ public:
    *
    * Fixed variant
    */
-  template <typename T,
-            typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
+  template <typename T
+#ifdef TIMPI_HAVE_MPI
+            ,
+            typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0
+#endif
+            >
   inline void broadcast(T & data, const unsigned int root_id=0,
                         const bool identical_sizes=false) const;
 
+#ifdef TIMPI_HAVE_MPI
   /**
    * Take a possibly dynamically-sized local value and broadcast it to all
    * processors.  Optionally takes the \p root_id processor, which specifies the
@@ -1228,6 +1233,7 @@ public:
             typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
   inline void broadcast(T & data, const unsigned int root_id=0,
                         const bool identical_sizes=false) const;
+#endif
 
   /**
    * Blocking-broadcast range-of-pointers to one processor.  This

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -3333,8 +3333,12 @@ inline void Communicator::alltoall(std::vector<T,A> & buf) const
 
 
 
-template <typename T,
-          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>
+template <typename T
+#ifdef TIMPI_HAVE_MPI
+          ,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type
+#endif
+          >
 inline void Communicator::broadcast (T & timpi_mpi_var(data),
                                      const unsigned int root_id,
                                      const bool /* identical_sizes */) const
@@ -3357,6 +3361,7 @@ inline void Communicator::broadcast (T & timpi_mpi_var(data),
                 this->get()));
 }
 
+#ifdef TIMPI_HAVE_MPI
 template <typename T,
           typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type>
 inline void Communicator::broadcast (T & data,
@@ -3391,6 +3396,7 @@ inline void Communicator::broadcast (T & data,
   data = range[0];
 // #endif
 }
+#endif
 
 template <typename T, typename A,
           typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type>

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -285,6 +285,17 @@ bool Communicator::possibly_receive (unsigned int &,
   timpi_not_implemented();
 }
 
+template <typename T, typename A>
+inline void Communicator::allgather(const std::basic_string<T> & sendval,
+                                    std::vector<std::basic_string<T>,A> & recv,
+                                    const bool /*identical_buffer_sizes*/) const
+{
+  timpi_assert(this->size() == 1);
+
+  recv.resize(1);
+  recv[0] = sendval;
+}
+
 } // namespace TIMPI
 
 #endif // ifndef TIMPI_HAVE_MPI

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -99,8 +99,7 @@ void testGather()
   }
 
 
-
-  void testAllGatherString()
+  void testGatherString2()
   {
     std::vector<std::string> vals;
     TestCommWorld->gather(0, "Processor" + pt_number[TestCommWorld->rank() % 10], vals);
@@ -109,7 +108,17 @@ void testGather()
       TIMPI_UNIT_ASSERT( "Processor" + pt_number[i % 10]  == vals[i] );
   }
 
+  void testAllGatherString()
+  {
+    std::string send = "Processor" + std::to_string(TestCommWorld->rank());
+    std::vector<std::string> gathered;
 
+    TestCommWorld->allgather(send, gathered);
+
+    TIMPI_UNIT_ASSERT(gathered.size() == TestCommWorld->size());
+    for (std::size_t i = 0; i < gathered.size(); ++i)
+      TIMPI_UNIT_ASSERT(gathered[i] == "Processor" + std::to_string(i));
+  }
 
   void testAllGatherVectorString()
   {
@@ -166,7 +175,21 @@ void testGather()
       TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
   }
 
+  void testBroadcastString()
+  {
+    std::string src = "hello";
+    std::string dest = src;
 
+    // Clear dest on non-root ranks
+    if (TestCommWorld->rank() != 0)
+      dest.clear();
+
+    // By default the root_id is 0
+    TestCommWorld->broadcast(dest);
+
+    for (std::size_t i=0; i<src.size(); i++)
+      TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
+  }
 
   void testBroadcastNestedType()
   {
@@ -805,6 +828,7 @@ int main(int argc, const char * const * argv)
   testGather();
   testAllGather();
   testGatherString();
+  testGatherString2();
   testAllGatherString();
   testAllGatherVectorString();
   testAllGatherEmptyVectorString();
@@ -814,6 +838,7 @@ int main(int argc, const char * const * argv)
   testBroadcast<std::map<int, std::string>>({{0,"foo"}, {1,"bar"}, {2,"baz"}});
   testBroadcast<std::unordered_map<int, int>>({{0,0}, {1,1}, {2,2}});
   testBroadcast<std::unordered_map<int, std::string>>({{0,"foo"}, {1,"bar"}, {2,"baz"}});
+  testBroadcastString();
   testBroadcastNestedType();
   testScatter();
   testBarrier();


### PR DESCRIPTION
The use of `#ifdef TIMPI_HAVE_MPI` in `communicator.h` goes against the current design, but it's certainly the fewest lines of code to fix #55 I think. If there's a cleaner solution, then I'll change things here. The `allgather` implementation in `serial_implementation` is necessary otherwise we'll get undefined references when trying to link the unit tests (with the new `testAllGatherString` test)

Also refs libmesh/libmesh#2791