### PR TITLE
Packing<tuple> specialization

### DIFF
--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -364,7 +364,9 @@ struct CheckAllFixedTypes<Head>
 };
 
 template<typename... Types>
-class StandardType<std::tuple<Types...>> : public DataType
+class StandardType<std::tuple<Types...>,
+                   typename std::enable_if<
+                     CheckAllFixedTypes<Types...>::is_fixed_type>::type> : public DataType
 {
 public:
   explicit


### PR DESCRIPTION
This gives us a Packing specialization for any tuple that's not completely composed of fixed types, and removes those cases from the previous StandardType specialization, so variable-size data structures with tuples in them can now participate in automatic packing dispatch.

Hoping @lindsayad can look this over too; he did much of the hard work this is based on.

And, if it's not too late, @loganharbour might want to try this out, since he was the first one to try to communicate a vector of tuples with strings in them under the naive theory that just because we supported vectors and tuples and strings that would mean we must support vectors of tuples of strings too.