### PR TITLE
Packing<vector> support, set_union unit tests

### DIFF
--- a/src/parallel/include/timpi/packing.h
+++ b/src/parallel/include/timpi/packing.h
@@ -772,6 +772,9 @@ public:                                                   \
 #define TIMPI_P_COMMA ,
 
 template <typename T, typename A>
+TIMPI_PACKING_RANGE_SUBCLASS(std::vector<T TIMPI_P_COMMA A>);
+
+template <typename T, typename A>
 TIMPI_PACKING_RANGE_SUBCLASS(std::list<T TIMPI_P_COMMA A>);
 
 template <typename K, typename T, typename C, typename A>

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -116,6 +116,24 @@
     inline
     void set_union(std::map<T1,T2,C,A> &data) const;
 
+    template <typename K, typename H, typename KE, typename A>
+    inline
+    void set_union(std::unordered_set<K,H,KE,A> &data,
+                   const unsigned int root_id) const;
+
+    template <typename K, typename H, typename KE, typename A>
+    inline
+    void set_union(std::unordered_set<K,H,KE,A> &data) const;
+
+    template <typename K, typename T, typename H, typename KE, typename A>
+    inline
+    void set_union(std::unordered_map<K,T,H,KE,A> &data,
+                   const unsigned int root_id) const;
+
+    template <typename K, typename T, typename H, typename KE, typename A>
+    inline
+    void set_union(std::unordered_map<K,T,H,KE,A> &data) const;
+
     template <typename T, typename A1, typename A2>
     inline
     bool possibly_receive (unsigned int & src_processor_id,

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -2736,6 +2736,61 @@ inline void Communicator::set_union(std::map<T1,T2,C,A> & data) const
 }
 
 
+template <typename K, typename H, typename KE, typename A>
+inline void Communicator::set_union(std::unordered_set<K,H,KE,A> & data,
+                                    const unsigned int root_id) const
+{
+  if (this->size() > 1)
+    {
+      std::vector<K> vecdata(data.begin(), data.end());
+      this->gather(root_id, vecdata);
+      if (this->rank() == root_id)
+        data.insert(vecdata.begin(), vecdata.end());
+    }
+}
+
+
+
+template <typename K, typename H, typename KE, typename A>
+inline void Communicator::set_union(std::unordered_set<K,H,KE,A> & data) const
+{
+  if (this->size() > 1)
+    {
+      std::vector<K> vecdata(data.begin(), data.end());
+      this->allgather(vecdata, false);
+      data.insert(vecdata.begin(), vecdata.end());
+    }
+}
+
+
+
+template <typename K, typename T, typename H, typename KE, typename A>
+inline void Communicator::set_union(std::unordered_map<K,T,H,KE,A> & data,
+                                    const unsigned int root_id) const
+{
+  if (this->size() > 1)
+    {
+      std::vector<std::pair<K,T>> vecdata(data.begin(), data.end());
+      this->gather(root_id, vecdata);
+      if (this->rank() == root_id)
+        data.insert(vecdata.begin(), vecdata.end());
+    }
+}
+
+
+
+template <typename K, typename T, typename H, typename KE, typename A>
+inline void Communicator::set_union(std::unordered_map<K,T,H,KE,A> & data) const
+{
+  if (this->size() > 1)
+    {
+      std::vector<std::pair<K,T>> vecdata(data.begin(), data.end());
+      this->allgather(vecdata, false);
+      data.insert(vecdata.begin(), vecdata.end());
+    }
+}
+
+
 
 template <typename T, typename A>
 inline void Communicator::gather(const unsigned int root_id,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,6 +32,11 @@ if BUILD_DBG_MODE
   parallel_unit_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
   parallel_unit_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
 
+  set_unit_dbg_SOURCES = parallel_unit.C
+  set_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
+  set_unit_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
+  set_unit_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
+
   dispatch_to_packed_unit_dbg_SOURCES = dispatch_to_packed_unit.C
   dispatch_to_packed_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
   dispatch_to_packed_unit_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
@@ -41,6 +46,7 @@ if BUILD_DBG_MODE
   check_PROGRAMS += packed_range_unit-dbg
   check_PROGRAMS += parallel_sync_unit-dbg
   check_PROGRAMS += parallel_unit-dbg
+  check_PROGRAMS += set_unit-dbg
   check_PROGRAMS += dispatch_to_packed_unit-dbg
 endif
 
@@ -65,6 +71,11 @@ if BUILD_DEVEL_MODE
   parallel_unit_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
   parallel_unit_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
 
+  set_unit_devel_SOURCES = set_unit.C
+  set_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
+  set_unit_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
+  set_unit_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
+
   dispatch_to_packed_unit_devel_SOURCES = dispatch_to_packed_unit.C
   dispatch_to_packed_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
   dispatch_to_packed_unit_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
@@ -74,6 +85,7 @@ if BUILD_DEVEL_MODE
   check_PROGRAMS += packed_range_unit-devel
   check_PROGRAMS += parallel_sync_unit-devel
   check_PROGRAMS += parallel_unit-devel
+  check_PROGRAMS += set_unit-devel
   check_PROGRAMS += dispatch_to_packed_unit-devel
 endif
 
@@ -98,6 +110,11 @@ if BUILD_OPT_MODE
   parallel_unit_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
   parallel_unit_opt_CXXFLAGS = $(CXXFLAGS_OPT)
 
+  set_unit_opt_SOURCES = set_unit.C
+  set_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
+  set_unit_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
+  set_unit_opt_CXXFLAGS = $(CXXFLAGS_OPT)
+
   dispatch_to_packed_unit_opt_SOURCES = dispatch_to_packed_unit.C
   dispatch_to_packed_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
   dispatch_to_packed_unit_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
@@ -107,6 +124,7 @@ if BUILD_OPT_MODE
   check_PROGRAMS += packed_range_unit-opt
   check_PROGRAMS += parallel_sync_unit-opt
   check_PROGRAMS += parallel_unit-opt
+  check_PROGRAMS += set_unit-opt
   check_PROGRAMS += dispatch_to_packed_unit-opt
 endif
 
@@ -131,6 +149,11 @@ if BUILD_OPROF_MODE
   parallel_unit_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
   parallel_unit_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 
+  set_unit_oprof_SOURCES = set_unit.C
+  set_unit_oprof_LDFLAGS = $(top_builddir)/src/libtimpi_oprof.la
+  set_unit_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
+  set_unit_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
+
   dispatch_to_packed_unit_oprof_SOURCES = dispatch_to_packed_unit.C
   dispatch_to_packed_unit_oprof_LDFLAGS = $(top_builddir)/src/libtimpi_oprof.la
   dispatch_to_packed_unit_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
@@ -140,6 +163,7 @@ if BUILD_OPROF_MODE
   check_PROGRAMS += packed_range_unit-oprof
   check_PROGRAMS += parallel_sync_unit-oprof
   check_PROGRAMS += parallel_unit-oprof
+  check_PROGRAMS += set_unit-oprof
   check_PROGRAMS += dispatch_to_packed_unit-oprof
 endif
 
@@ -164,6 +188,11 @@ if BUILD_PROF_MODE
   parallel_unit_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
   parallel_unit_prof_CXXFLAGS = $(CXXFLAGS_PROF)
 
+  set_unit_prof_SOURCES = set_unit.C
+  set_unit_prof_LDFLAGS = $(top_builddir)/src/libtimpi_prof.la
+  set_unit_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
+  set_unit_prof_CXXFLAGS = $(CXXFLAGS_PROF)
+
   dispatch_to_packed_unit_prof_SOURCES = dispatch_to_packed_unit.C
   dispatch_to_packed_unit_prof_LDFLAGS = $(top_builddir)/src/libtimpi_prof.la
   dispatch_to_packed_unit_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
@@ -173,6 +202,7 @@ if BUILD_PROF_MODE
   check_PROGRAMS += packed_range_unit-prof
   check_PROGRAMS += parallel_sync_unit-prof
   check_PROGRAMS += parallel_unit-prof
+  check_PROGRAMS += set_unit-prof
   check_PROGRAMS += dispatch_to_packed_unit-prof
 endif
 

--- a/test/set_unit.C
+++ b/test/set_unit.C
@@ -11,6 +11,37 @@ using namespace TIMPI;
 
 Communicator *TestCommWorld;
 
+void inserter(std::set<int> & s, int i)
+{ s.insert(i); }
+
+void inserter(std::unordered_set<int> & s, int i)
+{ s.insert(i); }
+
+void inserter(std::map<int, int> & m, int i)
+{ m.insert(std::make_pair(i,2*i+3)); }
+
+void inserter(std::unordered_map<int, int> & m, int i)
+{ m.insert(std::make_pair(i,2*i+3)); }
+
+
+void tester(const std::set<int> & s, int i)
+{ TIMPI_UNIT_ASSERT( s.count(i) == std::size_t(1) ); }
+
+void tester(const std::unordered_set<int> & s, int i)
+{ TIMPI_UNIT_ASSERT( s.count(i) == std::size_t(1) ); }
+
+void tester(const std::map<int, int> & m, int i)
+{
+  TIMPI_UNIT_ASSERT( m.count(i) == std::size_t(1) );
+  TIMPI_UNIT_ASSERT( m.at(i) == 2*i+3 );
+}
+
+void tester(const std::unordered_map<int, int> & m, int i)
+{
+  TIMPI_UNIT_ASSERT( m.count(i) == std::size_t(1) );
+  TIMPI_UNIT_ASSERT( m.at(i) == 2*i+3 );
+}
+
 
   template <class Set>
   void testUnion()
@@ -19,18 +50,18 @@ Communicator *TestCommWorld;
 
     const int N = TestCommWorld->size();
 
-    data.insert(TestCommWorld->rank());
-    data.insert(2*N);
-    data.insert(3*N + TestCommWorld->rank());
+    inserter(data, TestCommWorld->rank());
+    inserter(data, 2*N);
+    inserter(data, 3*N + TestCommWorld->rank());
 
     TestCommWorld->set_union(data);
 
     TIMPI_UNIT_ASSERT( data.size() == std::size_t(2*N+1) );
-    TIMPI_UNIT_ASSERT( data.count(2*N) == std::size_t(1) );
+    tester(data, 2*N);
     for (int p=0; p<N; ++p)
       {
-        TIMPI_UNIT_ASSERT( data.count(p) == std::size_t(1) );
-        TIMPI_UNIT_ASSERT( data.count(3*N+p) == std::size_t(1) );
+        tester(data, p);
+        tester(data, 3*N+p);
       }
   }
 
@@ -41,9 +72,9 @@ int main(int argc, const char * const * argv)
   TestCommWorld = &init.comm();
 
   testUnion<std::set<int>>();
-
-  // TODO
-  // testUnion<std::unordered_set<int>>();
+  testUnion<std::unordered_set<int>>();
+  testUnion<std::map<int, int>>();
+  testUnion<std::unordered_map<int, int>>();
 
   return 0;
 }

--- a/test/set_unit.C
+++ b/test/set_unit.C
@@ -11,21 +11,33 @@ using namespace TIMPI;
 
 Communicator *TestCommWorld;
 
-void inserter(std::set<int> & s, int i)
+void my_inserter(std::set<int> & s, int i)
 { s.insert(i); }
 
-void inserter(std::unordered_set<int> & s, int i)
+void my_inserter(std::set<std::vector<int>> & s, int i)
+{ s.insert(std::vector<int>(i,i)); }
+
+void my_inserter(std::unordered_set<int> & s, int i)
 { s.insert(i); }
 
-void inserter(std::map<int, int> & m, int i)
+void my_inserter(std::map<int, int> & m, int i)
 { m.insert(std::make_pair(i,2*i+3)); }
 
-void inserter(std::unordered_map<int, int> & m, int i)
+void my_inserter(std::map<int, std::vector<int>> & m, int i)
+{ m.insert(std::make_pair(i,std::vector<int>(i,2*i+3))); }
+
+void my_inserter(std::unordered_map<int, int> & m, int i)
 { m.insert(std::make_pair(i,2*i+3)); }
+
+void my_inserter(std::unordered_map<int, std::vector<int>> & m, int i)
+{ m.insert(std::make_pair(i,std::vector<int>(i,2*i+3))); }
 
 
 void tester(const std::set<int> & s, int i)
 { TIMPI_UNIT_ASSERT( s.count(i) == std::size_t(1) ); }
+
+void tester(const std::set<std::vector<int>> & s, int i)
+{ TIMPI_UNIT_ASSERT( s.count(std::vector<int>(i,i)) == std::size_t(1) ); }
 
 void tester(const std::unordered_set<int> & s, int i)
 { TIMPI_UNIT_ASSERT( s.count(i) == std::size_t(1) ); }
@@ -36,11 +48,28 @@ void tester(const std::map<int, int> & m, int i)
   TIMPI_UNIT_ASSERT( m.at(i) == 2*i+3 );
 }
 
+void tester(const std::map<int, std::vector<int>> & m, int i)
+{
+  TIMPI_UNIT_ASSERT( m.count(i) == std::size_t(1) );
+  TIMPI_UNIT_ASSERT( m.at(i).size() == std::size_t(i) );
+  for (auto val : m.at(i))
+    TIMPI_UNIT_ASSERT( val == 2*i+3 );
+}
+
 void tester(const std::unordered_map<int, int> & m, int i)
 {
   TIMPI_UNIT_ASSERT( m.count(i) == std::size_t(1) );
   TIMPI_UNIT_ASSERT( m.at(i) == 2*i+3 );
 }
+
+void tester(const std::unordered_map<int, std::vector<int>> & m, int i)
+{
+  TIMPI_UNIT_ASSERT( m.count(i) == std::size_t(1) );
+  TIMPI_UNIT_ASSERT( m.at(i).size() == std::size_t(i) );
+  for (auto val : m.at(i))
+    TIMPI_UNIT_ASSERT( val == 2*i+3 );
+}
+
 
 
   template <class Set>
@@ -50,9 +79,9 @@ void tester(const std::unordered_map<int, int> & m, int i)
 
     const int N = TestCommWorld->size();
 
-    inserter(data, TestCommWorld->rank());
-    inserter(data, 2*N);
-    inserter(data, 3*N + TestCommWorld->rank());
+    my_inserter(data, TestCommWorld->rank());
+    my_inserter(data, 2*N);
+    my_inserter(data, 3*N + TestCommWorld->rank());
 
     TestCommWorld->set_union(data);
 
@@ -75,6 +104,15 @@ int main(int argc, const char * const * argv)
   testUnion<std::unordered_set<int>>();
   testUnion<std::map<int, int>>();
   testUnion<std::unordered_map<int, int>>();
+
+  // TODO: allgather(vector<vector>)
+  // testUnion<std::set<std::vector<int>>>();
+
+  // No std::hash<vector<non-bool>>
+  // testUnion<std::unordered_set<std::vector<int>>>();
+
+  testUnion<std::map<int, std::vector<int>>>();
+  testUnion<std::unordered_map<int, std::vector<int>>>();
 
   return 0;
 }

--- a/test/set_unit.C
+++ b/test/set_unit.C
@@ -1,0 +1,49 @@
+#include <timpi/timpi.h>
+
+#include <set>
+#include <unordered_set>
+
+#define TIMPI_UNIT_ASSERT(expr) \
+  if (!(expr)) \
+    timpi_error();
+
+using namespace TIMPI;
+
+Communicator *TestCommWorld;
+
+
+  template <class Set>
+  void testUnion()
+  {
+    Set data;
+
+    const int N = TestCommWorld->size();
+
+    data.insert(TestCommWorld->rank());
+    data.insert(2*N);
+    data.insert(3*N + TestCommWorld->rank());
+
+    TestCommWorld->set_union(data);
+
+    TIMPI_UNIT_ASSERT( data.size() == std::size_t(2*N+1) );
+    TIMPI_UNIT_ASSERT( data.count(2*N) == std::size_t(1) );
+    for (int p=0; p<N; ++p)
+      {
+        TIMPI_UNIT_ASSERT( data.count(p) == std::size_t(1) );
+        TIMPI_UNIT_ASSERT( data.count(3*N+p) == std::size_t(1) );
+      }
+  }
+
+
+int main(int argc, const char * const * argv)
+{
+  TIMPI::TIMPIInit init(argc, argv);
+  TestCommWorld = &init.comm();
+
+  testUnion<std::set<int>>();
+
+  // TODO
+  // testUnion<std::unordered_set<int>>();
+
+  return 0;
+}


### PR DESCRIPTION
This is hopefully sufficient to solve the issue in #69, and hopefully won't break (or pessimize, if our custom vector<vector> overloads were to suddenly stop getting preferred to packed_range dispatch) any other code paths, but I'm not 100% certain of any of that.