### PR TITLE
Add StandardType forward declaration header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Makefile.in
 aclocal.m4
+timpi_config.h.tmp.in
 timpi_config.h.tmp.in~
 timpi_config.h
 autom4te.cache

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,6 +93,7 @@ include_HEADERS += parallel/include/timpi/post_wait_unpack_nested_buffer.h
 include_HEADERS += parallel/include/timpi/post_wait_work.h
 include_HEADERS += parallel/include/timpi/request.h
 include_HEADERS += parallel/include/timpi/serial_implementation.h
+include_HEADERS += parallel/include/timpi/standard_type_forward.h
 include_HEADERS += parallel/include/timpi/standard_type.h
 include_HEADERS += parallel/include/timpi/status.h
 

--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -22,6 +22,7 @@
 // TIMPI includes
 #include "timpi/data_type.h"
 #include "timpi/timpi_config.h"
+#include "timpi/standard_type_forward.h"
 
 // C/C++ includes
 #ifdef TIMPI_HAVE_MPI
@@ -72,7 +73,7 @@ struct standardtype_dependent_false : std::false_type
  * More complicated data types may need to provide a pointer-to-T so
  * that we can use MPI_Address without constructing a new T.
  */
-template <typename T, typename Enable = void>
+template <typename T, typename Enable>
 class StandardType : public NotADataType
 {
   /*

--- a/src/parallel/include/timpi/standard_type_forward.h
+++ b/src/parallel/include/timpi/standard_type_forward.h
@@ -1,0 +1,27 @@
+// The TIMPI Message-Passing Parallelism Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef TIMPI_STANDARD_TYPE_FORWARD_H
+#define TIMPI_STANDARD_TYPE_FORWARD_H
+
+namespace TIMPI
+{
+template <typename, typename = void>
+class StandardType;
+}
+
+#endif // TIMPI_STANDARD_TYPE_FORWARD_H


### PR DESCRIPTION
Because the StandardType template takes a defaulted argument, it's
important to ensure that any declarations ahead of the class definition
illustrate that (otherwise the compiler wil error)