### PR TITLE
Make DataType destructor virtual

### DIFF
--- a/src/parallel/include/timpi/data_type.h
+++ b/src/parallel/include/timpi/data_type.h
@@ -68,7 +68,7 @@ public:
     this->commit();
   }
 
-  ~DataType () = default;
+  virtual ~DataType () = default;
 
   DataType & operator = (const DataType & other) = default;
   DataType & operator = (DataType && other) = default;


### PR DESCRIPTION
As evidenced by the number of errors I get if I make this destructor
protected, we delete from `DataType` quite a bit. Consequently we have
to make sure that the `StandardType` destructor gets called because that
is generally what calls `free()`. This is ultimately what slew
idaholab/moose#19246, causing valgrind errors in
https://civet.inl.gov/job/880361/, and leading to reversion in
idaholab/moose#19331