### PR TITLE
Implement copy assignment operators for StandardType

### DIFF
--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -195,6 +195,13 @@ TIMPI_STANDARD_TYPE(long double,MPI_LONG_DOUBLE);
       timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
     }
 
+    StandardType & operator=(StandardType & t)
+    {
+      this->free();
+      timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+      return *this;
+    }
+
     ~StandardType() {
       this->free();
     }
@@ -276,6 +283,13 @@ public:
       (MPI_Type_dup (t._datatype, &_datatype));
   }
 
+  StandardType & operator=(StandardType & t)
+  {
+    this->free();
+    timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+    return *this;
+  }
+
   ~StandardType() { this->free(); }
 
   static const bool is_fixed_type = true;
@@ -350,6 +364,13 @@ public:
       (MPI_Type_dup (t._datatype, &_datatype));
   }
 
+  StandardType & operator=(StandardType & t)
+  {
+    this->free();
+    timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+    return *this;
+  }
+
   ~StandardType() { this->free(); }
 
   static const bool is_fixed_type = true;
@@ -386,7 +407,7 @@ void BuildStandardTypeVector<n_minus_i>::build
     ith_type;
 
   out_vec.emplace_back
-    (new StandardType<ith_type>
+    (std::make_unique<StandardType<ith_type>>
      (&std::get<sizeof...(Types)-n_minus_i>(example)));
 
   BuildStandardTypeVector<n_minus_i-1>::build(out_vec, example);
@@ -504,6 +525,13 @@ public:
   {
     timpi_call_mpi
       (MPI_Type_dup (t._datatype, &_datatype));
+  }
+
+  StandardType & operator=(StandardType & t)
+  {
+    this->free();
+    timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+    return *this;
   }
 
   ~StandardType() { this->free(); }

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -849,6 +849,15 @@ void testGather()
     TIMPI_UNIT_ASSERT(subcomm.size() <= TestCommWorld->size());
   }
 
+  template <typename NonBuiltin>
+  void testStandardTypeAssignment()
+  {
+    NonBuiltin ex{};
+    StandardType<NonBuiltin> a(&ex);
+    StandardType<NonBuiltin> b(&ex);
+    a = b;
+  }
+
 
 int main(int argc, const char * const * argv)
 {
@@ -901,6 +910,10 @@ int main(int argc, const char * const * argv)
   testNonblockingSum();
   testNonblockingMin();
   testNonblockingMax();
+  testStandardTypeAssignment<TIMPI_DEFAULT_SCALAR_TYPE>();
+  testStandardTypeAssignment<std::pair<unsigned, unsigned>>();
+  testStandardTypeAssignment<std::array<unsigned, 1>>();
+  testStandardTypeAssignment<std::tuple<unsigned, unsigned, unsigned>>();
 
   return 0;
 }


### PR DESCRIPTION
Maybe I can drum up a test that would not have been valgrind clean before this change. Shouldn't be very hard