### PR TITLE
Expanded OpFunction capabilities

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ include_HEADERS += parallel/include/timpi/status.h
 
 # utilities
 include_HEADERS += utilities/include/timpi/ignore_warnings.h
+include_HEADERS += utilities/include/timpi/semipermanent.h
 include_HEADERS += utilities/include/timpi/timpi.h
 include_HEADERS += utilities/include/timpi/timpi_assert.h
 include_HEADERS += utilities/include/timpi/timpi_call_mpi.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ timpi_SOURCES += parallel/src/message_tag.C
 timpi_SOURCES += parallel/src/request.C
 
 # utilities
+timpi_SOURCES += utilities/src/semipermanent.C
 timpi_SOURCES += utilities/src/timpi_assert.C
 timpi_SOURCES += utilities/src/timpi_init.C
 timpi_SOURCES += utilities/src/timpi_version.C

--- a/src/parallel/include/timpi/op_function.h
+++ b/src/parallel/include/timpi/op_function.h
@@ -240,7 +240,7 @@ private:
   static MPI_Op mpiname() { \
     static MPI_Op TIMPI_MPI_##mpiname = MPI_OP_NULL; \
     if (TIMPI_MPI_##mpiname == MPI_OP_NULL) \
-      TIMPIInit::add_semipermanent \
+      SemiPermanent::add \
         (std::make_unique<ManageOp>(timpi_mpi_##funcname, true, &TIMPI_MPI_##mpiname)); \
     return TIMPI_MPI_##mpiname;  \
   }

--- a/src/utilities/include/timpi/semipermanent.h
+++ b/src/utilities/include/timpi/semipermanent.h
@@ -21,23 +21,57 @@
 #define TIMPI_SEMIPERMANENT_H
 
 
+// Local includes
+#include "timpi/timpi_config.h"
+
+// C/C++ includes
+
+#include <memory>
+#include <vector>
+
 namespace TIMPI
 {
+
+// Forward declare friend
+class TIMPIInit;
 
 /**
  * The \p SemiPermanent "class" is basically just a place for a
  * destructor vtable.  Derive from it and pass a unique_ptr to your
- * derived object to TIMPIInit::add_semipermanent() whenever you have
+ * derived object to SemiPermanent::add() whenever you have
  * something that ought to be *almost* permanent: that should be
  * cleaned up eventually to avoid resource leaks, but that should not
  * be cleaned up until the last TIMPIInit object exits, just before
  * the MPI_Finalize call if TIMPI initialized MPI.
  */
 
-struct SemiPermanent
+class SemiPermanent
 {
+public:
   SemiPermanent() = default;
   virtual ~SemiPermanent() = default;
+
+  /*
+   * Transfer ownership of a pointer to some "SemiPermanent" objects,
+   * to be destroyed (and thereby do any necessary cleanup work)
+   * whenever the last TIMPIInit is destroyed, before MPI is
+   * finalized.
+   */
+  static void add(std::unique_ptr<SemiPermanent> obj);
+
+  // Class to hold a reference to the SemiPermanent objects; they will
+  // only be destructed when the last Ref is.
+  struct Ref {
+    Ref() { _ref_count++; }
+    ~Ref();
+  };
+
+private:
+
+  // Mechanisms to avoid leaks after every TIMPIInit has been
+  // destroyed
+  static int _ref_count;
+  static std::vector<std::unique_ptr<SemiPermanent>> _stuff_to_clean;
 };
 
 

--- a/src/utilities/include/timpi/semipermanent.h
+++ b/src/utilities/include/timpi/semipermanent.h
@@ -1,0 +1,46 @@
+// The TIMPI Message-Passing Parallelism Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef TIMPI_SEMIPERMANENT_H
+#define TIMPI_SEMIPERMANENT_H
+
+
+namespace TIMPI
+{
+
+/**
+ * The \p SemiPermanent "class" is basically just a place for a
+ * destructor vtable.  Derive from it and pass a unique_ptr to your
+ * derived object to TIMPIInit::add_semipermanent() whenever you have
+ * something that ought to be *almost* permanent: that should be
+ * cleaned up eventually to avoid resource leaks, but that should not
+ * be cleaned up until the last TIMPIInit object exits, just before
+ * the MPI_Finalize call if TIMPI initialized MPI.
+ */
+
+struct SemiPermanent
+{
+  SemiPermanent() = default;
+  virtual ~SemiPermanent() = default;
+};
+
+
+} // namespace TIMPI
+
+#endif // TIMPI_SEMIPERMANENT_H

--- a/src/utilities/include/timpi/timpi_init.h
+++ b/src/utilities/include/timpi/timpi_init.h
@@ -123,22 +123,6 @@ private:
 #endif
 };
 
-/**
- * The \p SemiPermanent "class" is basically just a place for a
- * destructor vtable.  Derive from it and pass a unique_ptr to your
- * derived object to TIMPIInit::add_semipermanent() whenever you have
- * something that ought to be *almost* permanent: that should be
- * cleaned up eventually to avoid resource leaks, but that should not
- * be cleaned up until the last TIMPIInit object exits, just before
- * the MPI_Finalize call if TIMPI initialized MPI.
- */
-
-struct SemiPermanent
-{
-  SemiPermanent() = default;
-  virtual ~SemiPermanent() = default;
-};
-
 
 } // namespace TIMPI
 

--- a/src/utilities/include/timpi/timpi_init.h
+++ b/src/utilities/include/timpi/timpi_init.h
@@ -24,6 +24,8 @@
 // Local includes
 #include "timpi/timpi_config.h"
 
+#include "timpi/semipermanent.h"
+
 // C/C++ includes
 
 #ifdef TIMPI_HAVE_MPI
@@ -33,14 +35,12 @@
 #endif // #ifdef TIMPI_HAVE_MPI
 
 #include <memory>
-#include <vector>
 
 namespace TIMPI
 {
 
 // Forward declarations
   class Communicator;
-  class SemiPermanent;
 
 /**
  * The \p TIMPIInit class, when constructed, initializes
@@ -99,21 +99,11 @@ public:
 
   Communicator & comm() { return *_comm; }
 
-  /*
-   * Transfer ownership of a pointer to some "SemiPermanent" objects,
-   * to be destroyed (and thereby do any necessary cleanup work)
-   * whenever the last TIMPIInit is destroyed, before MPI is
-   * finalized.
-   */
-  static void add_semipermanent(std::unique_ptr<SemiPermanent> obj);
-
 private:
-  Communicator * _comm;
+  std::unique_ptr<Communicator> _comm;
 
-  // Mechanisms to avoid leaks after every TIMPIInit has been
-  // destroyed
-  static int _ref_count;
-  static std::vector<std::unique_ptr<SemiPermanent>> _stuff_to_clean;
+  // unique_ptr so we can free it *before* we MPI_Finalize
+  std::unique_ptr<SemiPermanent::Ref> _ref;
 
 #ifdef TIMPI_HAVE_MPI
   bool i_initialized_mpi;

--- a/src/utilities/src/semipermanent.C
+++ b/src/utilities/src/semipermanent.C
@@ -1,0 +1,51 @@
+// The TIMPI Message-Passing Parallelism Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+// Local includes
+#include "timpi/semipermanent.h"
+
+#include "timpi/timpi_assert.h"
+
+namespace TIMPI
+{
+
+int SemiPermanent::_ref_count = 0;
+
+std::vector<std::unique_ptr<SemiPermanent>> SemiPermanent::_stuff_to_clean;
+
+
+SemiPermanent::Ref::~Ref()
+{
+  _ref_count--;
+
+  // Last one to leave turns out the lights
+  if (_ref_count <= 0)
+    _stuff_to_clean.clear();
+}
+
+
+void SemiPermanent::add(std::unique_ptr<SemiPermanent> obj)
+{
+  timpi_assert_greater(_ref_count, 0);
+
+  _stuff_to_clean.push_back(std::move(obj));
+}
+
+}
+
+

--- a/src/utilities/src/timpi_init.C
+++ b/src/utilities/src/timpi_init.C
@@ -19,6 +19,8 @@
 // Local includes
 #include "timpi/timpi_init.h"
 
+#include "timpi/semipermanent.h"
+
 // TIMPI includes
 #include "timpi/communicator.h"
 #include "timpi/timpi_assert.h"

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -45,6 +45,24 @@ std::vector<std::string> pt_number;
 
 
 
+  template <class Gettable>
+  void testSumOpFunction()
+  {
+    Gettable data;
+
+    int N = TestCommWorld->size();
+
+    std::get<0>(data) = TestCommWorld->rank();
+    std::get<1>(data) = TestCommWorld->rank()*2;
+
+    TestCommWorld->sum(data);
+
+    TIMPI_UNIT_ASSERT(std::get<0>(data) == N*(N-1)/2);
+    TIMPI_UNIT_ASSERT(std::get<1>(data) == N*(N-1));
+  }
+
+
+
   template <class Map>
   void testNonFixedTypeSum()
   {
@@ -859,6 +877,7 @@ int main(int argc, const char * const * argv)
 
   testSum<std::map<int,int>>();
   testSum<std::unordered_map<int,int>>();
+  testSumOpFunction<std::pair<int,int>>();
   testNonFixedTypeSum<std::map<std::string,int>>();
   testNonFixedTypeSum<std::unordered_map<std::string,int>>();
   testGather();


### PR DESCRIPTION
This solves the tiny leak in our quad-precision on-the-the-fly-`MPI_Op` support, and more importantly it extends that support to std::pair and adds a unit test for it.  There's still a ton of work to be done here (and in MetaPhysicL), but I'm throwing this up now that it's passing tests, to see if anyone (or any CI tests) has criticisms.

This is our first-ever "do not merge"-labeled TIMPI PR because I'm still not 100% sure of the API myself.  I think I may move the new static members and APIs from `TIMPIInit` to `SemiPermanent` (even though the `TIMPIInit` destructor will still have to access them, we can make it a friend class), and I should probably replace `FreeOp` with something that does both halves of the create+free, to make that be a proper RAII class.