### PR TITLE
Use SemiPermanent for derived StandardType classes

### DIFF
--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -209,23 +209,24 @@ private:
   public:
     explicit
       StandardType(const TIMPI_DEFAULT_SCALAR_TYPE * = nullptr) : DataType() {
-        timpi_call_mpi(MPI_Type_contiguous(2, MPI_DOUBLE, &_datatype));
-        this->commit();
+        static data_type static_type = MPI_DATATYPE_NULL;
+        if (static_type == MPI_DATATYPE_NULL)
+          {
+            timpi_call_mpi(MPI_Type_contiguous(2, MPI_DOUBLE, &static_type));
+            SemiPermanent::add
+              (std::make_unique<ManageType>(static_type));
+          }
+        _datatype = static_type;
       }
 
     StandardType(const StandardType<TIMPI_DEFAULT_SCALAR_TYPE> & t) : DataType() {
-      timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
+      _datatype = t._datatype;
     }
 
     StandardType & operator=(StandardType & t)
     {
-      this->free();
-      timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+      _datatype = t._datatype;
       return *this;
-    }
-
-    ~StandardType() {
-      this->free();
     }
 
     static const bool is_fixed_type = true;

--- a/src/utilities/src/timpi_init.C
+++ b/src/utilities/src/timpi_init.C
@@ -128,8 +128,6 @@ TIMPIInit::~TIMPIInit()
   // one processor to try to exit until all others are done working.
   this->comm().barrier();
 
-  // timpi_assert_greater(_ref_count, 0); // Can't throw in destructors
-
   // Trigger any SemiPermanent cleanup before potentially finalizing MPI
   _ref.reset();
 


### PR DESCRIPTION
In #38 we got a few percent speedup by pulling a `MPI_Type_commit/MPI_Type_free` pair out of one inner loop, but by using the SemiPermanent capability from #80 we can avoid redundant derived type creations and deletions entirely.

This still makes valgrind happy for me, but on my system it took extra valgrind options to reliably sense any bugs, so I'll wait to merge until after our CI recipes have been updated to add the extra options and I kick the branch to use the updated recipes.