### PR TITLE
Update compiler requirements from C++11 to C++14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,12 +70,15 @@ dnl------------------------------
 TIMPI_SET_COMPILERS
 
 # --------------------------------------------------------------
-# Standard autoconf macro for determining the proper -std=c++11
-# flag for the current compiler.  Adds the result to CXXFLAGS if
-# one is found.  See ax_cxx_compile_stdcxx_11.m4 for details.
+# Autoconf macro for determining the proper -std=c++??
+# flag, for the current compiler, for the user's requested C++
+# standards level.  Adds the required flag to CXXFLAGS if
+# one is found.  Exits if no acceptable flag is found.
+#
+# We've started using C++14 code in TIMPI; we'll be requiring C++17
+# too shortly so we might as well enable it when it's found.
 # --------------------------------------------------------------
-enablecxx11=yes
-AX_CXX_COMPILE_STDCXX_11([],[mandatory])
+ACSM_CXX_COMPILER_STANDARD([2014], [2017])
 
 #-----------------------------------------------------
 # Set compiler flags for devel, opt, etc. methods

--- a/m4/acsm_cxx_tests.m4
+++ b/m4/acsm_cxx_tests.m4
@@ -1,0 +1,14 @@
+dnl ----------------------------------------------------------------
+dnl Test callback for use with ACSM.
+dnl ----------------------------------------------------------------
+
+dnl Currently we don't bother with extra tests ourselves.
+dnl
+dnl This is in the ACSM namespace because it is a "callback" from an
+dnl ACSM macro.
+
+AC_DEFUN([ACSM_TEST_CXX_ALL],
+  [
+    # Roll the dice!
+    have_cxx_all=yes
+  ])


### PR DESCRIPTION
This should keep us working with older compilers (once that support
C++14 but don't default to it) for a little longer, until we're ready for C++17.