### PR TITLE
Simplify logic in parallel sync nbx helper

### DIFF
--- a/test/parallel_sync_unit.C
+++ b/test/parallel_sync_unit.C
@@ -609,9 +609,9 @@ int main(int argc, const char * const * argv)
   // partitioned into M parts with M > N, then subpartition p belongs
   // to processor p%N.  Let's make M > N for these tests.
   testPushOversized();
-  // testPullOversized();
+  testPullOversized();
   testPushVecVecOversized();
-  // testPullVecVecOversized();
+  testPullVecVecOversized();
   testPushMultimapOversized();
   testPushMultimapVecVecOversized();
 


### PR DESCRIPTION
Random improvements while I'm digging through this.

Will probably need `timpi_make_unique` for c++ 11