### PR TITLE
prevent gcc spurious warnings

### DIFF
--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -213,7 +213,9 @@ void testGather()
   {
     using std::array;
     typedef array<array<int, 3>, 2> aa;
-    std::vector<aa> src(3), dest(3);
+
+    aa x;
+    std::vector<aa> src(3), dest(3,x);
 
     src[0][0][0] = 0;
     src[0][0][1] = -1;


### PR DESCRIPTION
After updating my compiler and libMesh-library, I got fetched by [gcc's spurious warning](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100366) which was resolved in the analogous [libmesh-test](https://github.com/libMesh/libmesh/pull/3097#discussion_r764063418).

For some reason, you seemingly never ran into this?
(my gcc-version is 11.2.0).

Best regards