### PR TITLE
Append to $LIBS, don't override $LIBS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,7 +143,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/parallel/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/utilities/include
 AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #timpi_version.h, timpi_config.h
 
-LIBS         = $(timpi_optional_LIBS)
+LIBS        += $(timpi_optional_LIBS)
 
 
 # Note that for "make test_headers" this DEFAULT_HEADERS_TO_TEST business allows us


### PR DESCRIPTION
This lets us do things like using linker flags instead of wrapper
scripts to get MPI support, which I need to test with my system's
clang++ 13 without rolling my own MPI on top of it.