### PR TITLE
Bugfix for Packing<tuple>

### DIFF
--- a/src/parallel/include/timpi/packing.h
+++ b/src/parallel/include/timpi/packing.h
@@ -521,7 +521,7 @@ template <typename T1, typename... MoreTypes>
 struct TupleBufferType<T1, MoreTypes...> {
   typedef typename
     TupleBufferTypeHelper<Has_buffer_type<Packing<T1>>::value,
-                          Has_buffer_type<Packing<MoreTypes...>>::value,
+                          Has_buffer_type<Packing<std::tuple<MoreTypes...>>>::value,
                           T1, MoreTypes...>::buffer_type buffer_type;
 };
 


### PR DESCRIPTION
Somehow the old code here still compiled *if* the tuple contents weren't mixes of packed and fixed-size types *or if* the tuple contents were in the "right" (non-broken) order.