### PR TITLE
Better messages when timpi_parallel_only() fails

### DIFF
--- a/src/utilities/include/timpi/timpi_assert.h
+++ b/src/utilities/include/timpi/timpi_assert.h
@@ -196,9 +196,14 @@ struct casting_compare {
 // parallel on every processor at once
 
 #ifndef NDEBUG
-#define timpi_parallel_only(comm_obj) do {                            \
-    timpi_assert((comm_obj).verify(std::string(__FILE__)));           \
-    timpi_assert((comm_obj).verify(std::to_string(__LINE__))); } while (0)
+#define timpi_parallel_only(comm_obj) do {                                           \
+    timpi_assert_msg((comm_obj).verify(std::string(__FILE__).length()),              \
+                     "Different ranks are at different timpi_parallel_only points"); \
+    timpi_assert_msg((comm_obj).verify(std::string(__FILE__)),                       \
+                     "Different ranks are at different timpi_parallel_only points"); \
+    timpi_assert_msg((comm_obj).verify(std::to_string(__LINE__)),                    \
+                     "Different ranks are at different timpi_parallel_only points"); \
+  } while (0)
 #else
 #define timpi_parallel_only(comm_obj)  ((void) 0)
 #endif

--- a/src/utilities/include/timpi/timpi_assert.h
+++ b/src/utilities/include/timpi/timpi_assert.h
@@ -201,7 +201,7 @@ struct casting_compare {
                      "Different ranks are at different timpi_parallel_only points"); \
     timpi_assert_msg((comm_obj).verify(std::string(__FILE__)),                       \
                      "Different ranks are at different timpi_parallel_only points"); \
-    timpi_assert_msg((comm_obj).verify(std::to_string(__LINE__)),                    \
+    timpi_assert_msg((comm_obj).verify(__LINE__),                                    \
                      "Different ranks are at different timpi_parallel_only points"); \
   } while (0)
 #else


### PR DESCRIPTION
This category of warnings is in recent years being hit by a large
collection of programmers who are writing distributed-parallel codes for
the first time and could benefit from clearer messages when they get out
of sync, as opposed to the original collection of programmers who the
category was designed for, {me}.