### PR TITLE
Don't define `Packing` specializations we can't pack

### DIFF
--- a/src/parallel/include/timpi/packing.h
+++ b/src/parallel/include/timpi/packing.h
@@ -371,11 +371,13 @@ struct PairBufferTypeHelper<T1, false, T2, false>
 // specialization for std::pair
 template <typename T1, typename T2>
 class Packing<std::pair<T1, T2>,
-              typename std::enable_if<!TIMPI::StandardType<std::pair<T1, T2>>::is_fixed_type>::type>
+              typename std::enable_if<PairHasPacking<T1,T2>::value>::type>
 {
 public:
+  typedef typename std::remove_const<T1>::type cT1;
+
   typedef typename PairBufferTypeHelper
-      <T1, Has_buffer_type<Packing<T1>>::value,
+      <cT1, Has_buffer_type<Packing<cT1>>::value,
        T2, Has_buffer_type<Packing<T2>>::value>::buffer_type buffer_type;
 
   typedef PackingMixedType<buffer_type> Mixed;
@@ -397,7 +399,7 @@ template <typename T1, typename T2>
 template <typename Context>
 unsigned int
 Packing<std::pair<T1, T2>,
-        typename std::enable_if<!TIMPI::StandardType<std::pair<T1, T2>>::is_fixed_type>::type>::
+        typename std::enable_if<PairHasPacking<T1,T2>::value>::type>::
     packable_size(const std::pair<T1, T2> & pr, const Context * ctx)
 {
   return get_packed_len_entries<buffer_type>() +
@@ -409,7 +411,7 @@ template <typename T1, typename T2>
 template <typename BufferIter>
 unsigned int
 Packing<std::pair<T1, T2>,
-        typename std::enable_if<!TIMPI::StandardType<std::pair<T1, T2>>::is_fixed_type>::type>::
+        typename std::enable_if<PairHasPacking<T1,T2>::value>::type>::
     packed_size(BufferIter iter)
 {
   // We recorded the size in the first buffer entries
@@ -420,7 +422,7 @@ template <typename T1, typename T2>
 template <typename OutputIter, typename Context>
 void
 Packing<std::pair<T1, T2>,
-        typename std::enable_if<!TIMPI::StandardType<std::pair<T1, T2>>::is_fixed_type>::type>::
+        typename std::enable_if<PairHasPacking<T1,T2>::value>::type>::
     pack(const std::pair<T1, T2> & pr, OutputIter data_out, const Context * ctx)
 {
   unsigned int size = packable_size(pr, ctx);
@@ -443,7 +445,7 @@ template <typename T1, typename T2>
 template <typename BufferIter, typename Context>
 std::pair<T1, T2>
 Packing<std::pair<T1, T2>,
-        typename std::enable_if<!TIMPI::StandardType<std::pair<T1, T2>>::is_fixed_type>::type>::
+        typename std::enable_if<PairHasPacking<T1,T2>::value>::type>::
     unpack(BufferIter in, Context * ctx)
 {
   std::pair<T1, T2> pr;
@@ -519,38 +521,38 @@ struct TupleBufferType<T1, MoreTypes...>
 template <typename Enable>
 class Packing<std::tuple<>, Enable> {};
 
-template <typename... Types>
-class Packing<std::tuple<Types...>,
-              typename std::enable_if<!TIMPI::StandardType<std::tuple<Types...>>::is_fixed_type>::type>
+template <typename T, typename... Types>
+class Packing<std::tuple<T, Types...>,
+              typename std::enable_if<TupleHasPacking<T, Types...>::value>::type>
 {
 public:
-  typedef typename TupleBufferType<Types...>::buffer_type buffer_type;
+  typedef typename TupleBufferType<T, Types...>::buffer_type buffer_type;
 
   typedef PackingMixedType<buffer_type> Mixed;
 
   template <typename OutputIter, typename Context>
-  static void pack(const std::tuple<Types...> & tup, OutputIter data_out, const Context * context);
+  static void pack(const std::tuple<T, Types...> & tup, OutputIter data_out, const Context * context);
 
   template <typename Context>
-  static unsigned int packable_size(const std::tuple<Types...> & tup, const Context * context);
+  static unsigned int packable_size(const std::tuple<T, Types...> & tup, const Context * context);
 
   template <typename BufferIter>
   static unsigned int packed_size(BufferIter iter);
 
   template <typename BufferIter, typename Context>
-  static std::tuple<Types...> unpack(BufferIter in, Context * ctx);
+  static std::tuple<T, Types...> unpack(BufferIter in, Context * ctx);
 
   template <typename Context,
             std::size_t I>
-  static typename std::enable_if<I == sizeof...(Types), unsigned int>::type
-  tail_packable_size(const std::tuple<Types...> &,
+  static typename std::enable_if<I == sizeof...(Types)+1, unsigned int>::type
+  tail_packable_size(const std::tuple<T, Types...> &,
                      const Context *)
   { return 0; }
 
   template <typename Context,
             std::size_t I>
-  static typename std::enable_if<I < sizeof...(Types), unsigned int>::type
-  tail_packable_size(const std::tuple<Types...> &tup,
+  static typename std::enable_if<I < sizeof...(Types)+1, unsigned int>::type
+  tail_packable_size(const std::tuple<T, Types...> &tup,
                      const Context * ctx)
   {
     return Mixed::packable_size_comp(std::get<I>(tup), ctx) +
@@ -560,16 +562,16 @@ public:
   template <typename Context,
             typename OutputIter,
             std::size_t I>
-  static typename std::enable_if<I == sizeof...(Types), void>::type
-  tail_pack_comp(const std::tuple<Types...> &,
+  static typename std::enable_if<I == sizeof...(Types)+1, void>::type
+  tail_pack_comp(const std::tuple<T, Types...> &,
                  OutputIter,
                  const Context *) {}
 
   template <typename Context,
             typename OutputIter,
             std::size_t I>
-  static typename std::enable_if<I < sizeof...(Types), void>::type
-  tail_pack_comp(const std::tuple<Types...> &tup,
+  static typename std::enable_if<I < sizeof...(Types)+1, void>::type
+  tail_pack_comp(const std::tuple<T, Types...> &tup,
                  OutputIter data_out,
                  const Context * ctx)
   {
@@ -580,16 +582,16 @@ public:
   template <typename Context,
             typename BufferIter,
             std::size_t I>
-  static typename std::enable_if<I == sizeof...(Types), void>::type
-  tail_unpack_comp(std::tuple<Types...> &,
+  static typename std::enable_if<I == sizeof...(Types)+1, void>::type
+  tail_unpack_comp(std::tuple<T, Types...> &,
                    BufferIter &,
                    Context *) {}
 
   template <typename Context,
             typename BufferIter,
             std::size_t I>
-  static typename std::enable_if<I < sizeof...(Types), void>::type
-  tail_unpack_comp(std::tuple<Types...> &tup,
+  static typename std::enable_if<I < sizeof...(Types)+1, void>::type
+  tail_unpack_comp(std::tuple<T, Types...> &tup,
                    BufferIter & in,
                    Context * ctx)
   {
@@ -605,34 +607,34 @@ public:
 };
 
 
-template <typename... Types>
+template <typename T, typename... Types>
 template <typename Context>
 unsigned int
-Packing<std::tuple<Types...>,
-        typename std::enable_if<!TIMPI::StandardType<std::tuple<Types...>>::is_fixed_type>::type>::
-    packable_size(const std::tuple<Types...> & tup, const Context * ctx)
+Packing<std::tuple<T, Types...>,
+        typename std::enable_if<TupleHasPacking<T, Types...>::value>::type>::
+    packable_size(const std::tuple<T, Types...> & tup, const Context * ctx)
 {
   return get_packed_len_entries<buffer_type>() +
     tail_packable_size<Context, 0>(tup, ctx);
 }
 
-template <typename... Types>
+template <typename T, typename... Types>
 template <typename BufferIter>
 unsigned int
-Packing<std::tuple<Types...>,
-        typename std::enable_if<!TIMPI::StandardType<std::tuple<Types...>>::is_fixed_type>::type>::
+Packing<std::tuple<T, Types...>,
+        typename std::enable_if<TupleHasPacking<T, Types...>::value>::type>::
     packed_size(BufferIter iter)
 {
   // We recorded the size in the first buffer entries
   return get_packed_len<buffer_type>(iter);
 }
 
-template <typename... Types>
+template <typename T, typename... Types>
 template <typename OutputIter, typename Context>
 void
-Packing<std::tuple<Types...>,
-        typename std::enable_if<!TIMPI::StandardType<std::tuple<Types...>>::is_fixed_type>::type>::
-    pack(const std::tuple<Types...> & tup, OutputIter data_out, const Context * ctx)
+Packing<std::tuple<T, Types...>,
+        typename std::enable_if<TupleHasPacking<T, Types...>::value>::type>::
+    pack(const std::tuple<T, Types...> & tup, OutputIter data_out, const Context * ctx)
 {
   unsigned int size = packable_size(tup, ctx);
 
@@ -643,14 +645,14 @@ Packing<std::tuple<Types...>,
   tail_pack_comp<Context, OutputIter, 0>(tup, data_out, ctx);
 }
 
-template <typename... Types>
+template <typename T, typename... Types>
 template <typename BufferIter, typename Context>
-std::tuple<Types...>
-Packing<std::tuple<Types...>,
-        typename std::enable_if<!TIMPI::StandardType<std::tuple<Types...>>::is_fixed_type>::type>::
+std::tuple<T, Types...>
+Packing<std::tuple<T, Types...>,
+        typename std::enable_if<TupleHasPacking<T, Types...>::value>::type>::
     unpack(BufferIter in, Context * ctx)
 {
-  std::tuple<Types...> tup;
+  std::tuple<T, Types...> tup;
 
   // We ignore total size here but we have to increment past it
   constexpr int size_bytes = get_packed_len_entries<buffer_type>();
@@ -667,7 +669,7 @@ Packing<std::tuple<Types...>,
 // specialization for std::array
 template <typename T, std::size_t N>
 class Packing<std::array<T, N>,
-              typename std::enable_if<!TIMPI::StandardType<T>::is_fixed_type>::type>
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value>::type>
 {
 public:
   typedef typename Packing<T>::buffer_type buffer_type;
@@ -691,7 +693,7 @@ template <typename T, std::size_t N>
 template <typename Context>
 unsigned int
 Packing<std::array<T, N>,
-        typename std::enable_if<!TIMPI::StandardType<T>::is_fixed_type>::type>::
+        typename std::enable_if<Has_buffer_type<Packing<T>>::value>::type>::
     packable_size(const std::array<T, N> & a, const Context * ctx)
 {
   unsigned int returnval = get_packed_len_entries<buffer_type>(); // size
@@ -704,7 +706,7 @@ template <typename T, std::size_t N>
 template <typename BufferIter>
 unsigned int
 Packing<std::array<T, N>,
-        typename std::enable_if<!TIMPI::StandardType<T>::is_fixed_type>::type>::
+        typename std::enable_if<Has_buffer_type<Packing<T>>::value>::type>::
     packed_size(BufferIter iter)
 {
   // We recorded the size in the first buffer entries
@@ -715,7 +717,7 @@ template <typename T, std::size_t N>
 template <typename OutputIter, typename Context>
 void
 Packing<std::array<T, N>,
-        typename std::enable_if<!TIMPI::StandardType<T>::is_fixed_type>::type>::
+        typename std::enable_if<Has_buffer_type<Packing<T>>::value>::type>::
     pack(const std::array<T, N> & a, OutputIter data_out, const Context * ctx)
 {
   unsigned int size = packable_size(a, ctx);
@@ -732,7 +734,7 @@ template <typename T, std::size_t N>
 template <typename BufferIter, typename Context>
 std::array<T, N>
 Packing<std::array<T, N>,
-        typename std::enable_if<!TIMPI::StandardType<T>::is_fixed_type>::type>::
+        typename std::enable_if<Has_buffer_type<Packing<T>>::value>::type>::
     unpack(BufferIter in, Context * ctx)
 {
   std::array<T, N> a;
@@ -879,7 +881,10 @@ PackingRange<Container>::unpack(BufferIter in, Context * ctx)
 
 
 #define TIMPI_PACKING_RANGE_SUBCLASS(Container)           \
-class Packing<Container> : public PackingRange<Container> \
+class Packing<Container, \
+              typename std::enable_if<Has_buffer_type<Packing<typename Container::value_type>>::value || \
+                                      TIMPI::StandardType<typename Container::value_type>::is_fixed_type>::type> : \
+  public PackingRange<Container> \
 {                                                         \
 public:                                                   \
   using typename PackingRange<Container>::buffer_type;    \
@@ -925,7 +930,9 @@ TIMPI_PACKING_RANGE_SUBCLASS(std::unordered_set<K TIMPI_P_COMMA H TIMPI_P_COMMA 
 
 
 template <typename T>
-class Packing<std::basic_string<T>> {
+class Packing<std::basic_string<T>,
+              typename std::enable_if<TIMPI::StandardType<T>::is_fixed_type>::type>
+{
 public:
 
   typedef unsigned int buffer_type;

--- a/src/parallel/include/timpi/standard_type.h
+++ b/src/parallel/include/timpi/standard_type.h
@@ -306,10 +306,13 @@ private:
 # endif
 #endif
 
+// using remove_const here so our packing code can see a
+// `StandardType<pair<const K,T>>::is_fixed_type` and infer that it
+// can do memcpy on them
 template<typename T1, typename T2>
 class StandardType<std::pair<T1, T2>,
                    typename std::enable_if<
-                     StandardType<T1>::is_fixed_type &&
+                     StandardType<typename std::remove_const<T1>::type>::is_fixed_type &&
                      StandardType<T2>::is_fixed_type>::type> : public DataType
 {
 public:
@@ -328,7 +331,9 @@ public:
 
         // Get the sub-data-types, and make sure they live long enough
         // to construct the derived type
-        StandardType<T1> d1(&example->first);
+        StandardType<typename std::remove_const<T1>::type>
+          d1(const_cast<typename std::remove_const<T1>::type *>
+               (&example->first));
         StandardType<T2> d2(&example->second);
 
         MPI_Datatype types[] = { (data_type)d1, (data_type)d2 };

--- a/test/packed_range_unit.C
+++ b/test/packed_range_unit.C
@@ -218,6 +218,14 @@ Communicator *TestCommWorld;
   // other types.
   void testTupleStringAllGather()
   {
+    static_assert(Has_buffer_type<Packing<std::string>>::value);
+    static_assert(libMesh::Parallel::TupleHasPacking<std::string>::value);
+    static_assert(Has_buffer_type<Packing<std::tuple<std::string>>>::value);
+    static_assert(libMesh::Parallel::TupleHasPacking<std::string, std::string>::value);
+    static_assert(Has_buffer_type<Packing<std::tuple<std::string, std::string>>>::value);
+    static_assert(libMesh::Parallel::TupleHasPacking<std::string, std::string, int>::value);
+    static_assert(Has_buffer_type<Packing<std::tuple<std::string, std::string, int>>>::value);
+
     std::vector<std::tuple<std::string, std::string, int>> sendv(2);
 
     auto & s0 = std::get<1>(sendv[0]);
@@ -264,6 +272,10 @@ Communicator *TestCommWorld;
   void testNestingAllGather()
   {
     typedef std::tuple<unsigned int, std::vector<std::tuple<char,int,std::size_t>>, unsigned int> send_type;
+
+    static_assert(Has_buffer_type<Packing<std::vector<std::tuple<char,int,std::size_t>>>>::value);
+    static_assert(Has_buffer_type<Packing<send_type>>::value);
+
     std::vector<send_type> sendv(2);
 
     std::get<0>(sendv[0]) = 100;
@@ -576,6 +588,17 @@ Communicator *TestCommWorld;
   void testPushPackedOneTuple()
   {
     typedef std::tuple<std::unordered_map<unsigned int, std::string>> tuple_type;
+    static_assert(Has_buffer_type<Packing<std::string>>::value);
+    static_assert(TIMPI::StandardType<std::pair<unsigned int, unsigned int>>::is_fixed_type);
+    static_assert(TIMPI::StandardType<std::pair<const unsigned int, unsigned int>>::is_fixed_type);
+    static_assert(Has_buffer_type<Packing<std::unordered_map<unsigned int, unsigned int>>>::value);
+    static_assert(Has_buffer_type<Packing<std::pair<std::string, std::string>>>::value);
+    static_assert(Has_buffer_type<Packing<std::pair<const std::string, std::string>>>::value);
+    static_assert(Has_buffer_type<Packing<std::unordered_map<std::string, std::string>>>::value);
+    static_assert(Has_buffer_type<Packing<std::pair<unsigned int, std::string>>>::value);
+    static_assert(Has_buffer_type<Packing<std::pair<const unsigned int, std::string>>>::value);
+    static_assert(Has_buffer_type<Packing<std::unordered_map<unsigned int, std::string>>>::value);
+    static_assert(Has_buffer_type<Packing<tuple_type>>::value);
 
     auto fill_tuple = [] (int n)
       {


### PR DESCRIPTION
A `container<SomethingUnpackable>` should itself be recognized as unpackable, even if other `container<T>` can be handled.

This should let user code test `Has_buffer_type<Packing<T>>::value` and see false for types we can't pack.

I ought to throw some `static_assert(!Has_buffer_type<Packing<Foo>>::value)` for a bunch of unpackable foo into the test suite before we merge this, but the headers should be in shape for Logan to play with.