### PR TITLE
Options to use older sync algorithms

### DIFF
--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -609,7 +609,7 @@ void push_parallel_packed_range(const Communicator & comm,
         (comm, data, send_functor, receive_functor, act_on_data);
     }
     break;
-  case Communicator::BLOCKING:
+  case Communicator::SENDRECEIVE:
     {
       auto sendreceive_functor = [&context, &output_type, &comm]
         (const processor_id_type dest_pid,
@@ -713,7 +713,7 @@ void push_parallel_vector_data(const Communicator & comm,
         (comm, data, send_functor, receive_functor, act_on_data);
     }
     break;
-  case Communicator::BLOCKING:
+  case Communicator::SENDRECEIVE:
     {
       auto sendreceive_functor = [&comm](const processor_id_type dest_pid,
                                          const container_type & data_to_send,
@@ -770,9 +770,9 @@ void pull_parallel_vector_data(const Communicator & comm,
   for (auto p : queries)
     max_pid = std::max(max_pid, p.first);
 
-  // Our BLOCKING implementation doesn't preserve ordering, but we
+  // Our SENDRECEIVE implementation doesn't preserve ordering, but we
   // need ordering preserved for the multimap trick here to work.
-  if (comm.sync_type() == Communicator::BLOCKING &&
+  if (comm.sync_type() == Communicator::SENDRECEIVE &&
       max_pid > comm.size())
     timpi_not_implemented();
 #endif

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -885,8 +885,14 @@ public:
   /**
    * Send data \p send to one processor while simultaneously receiving
    * other data \p recv from a (potentially different) processor.
+   *
+   * This overload is defined for fixed-size data; other overloads
+   * exist for many other categories.
    */
-  template <typename T1, typename T2>
+  template <typename T1, typename T2,
+            typename std::enable_if<std::is_base_of<DataType, StandardType<T1>>::value &&
+                                    std::is_base_of<DataType, StandardType<T2>>::value,
+                                    int>::type = 0>
   inline
   void send_receive(const unsigned int dest_processor_id,
                     const T1 & send,

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -215,7 +215,7 @@ public:
   /**
    * What algorithm to use for parallel synchronization?
    */
-  enum SyncType { NBX, ALLTOALL_COUNTS, BLOCKING };
+  enum SyncType { NBX, ALLTOALL_COUNTS, SENDRECEIVE };
 
 
 private:

--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -212,6 +212,12 @@ public:
    */
   enum SendMode { DEFAULT=0, SYNCHRONOUS };
 
+  /**
+   * What algorithm to use for parallel synchronization?
+   */
+  enum SyncType { NBX, ALLTOALL_COUNTS, BLOCKING };
+
+
 private:
 
   /**
@@ -223,6 +229,7 @@ private:
   communicator  _communicator;
   processor_id_type _rank, _size;
   SendMode _send_mode;
+  SyncType _sync_type;
 
   // mutable used_tag_values and tag_queue - not thread-safe, but then
   // TIMPI:: isn't thread-safe in general.
@@ -322,6 +329,16 @@ public:
    * Gets the user-requested SendMode.
    */
   SendMode send_mode() const { return _send_mode; }
+
+  /**
+   * Explicitly sets the \p SyncType used for sync operations.
+   */
+  void sync_type (const SyncType st) { _sync_type = st; }
+
+  /**
+   * Gets the user-requested SyncType.
+   */
+  SyncType sync_type() const { return _sync_type; }
 
   /**
    * Pause execution until all processors reach a certain point.

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -355,6 +355,22 @@
                     const DataType &type,
                     const MessageTag &tag=any_tag) const;
 
+    template <typename T, typename A,
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type>
+    inline
+    Status receive (const unsigned int src_processor_id,
+                    std::vector<T,A> & buf,
+                    const DataType & type,
+                    const MessageTag & tag) const;
+
+    template <typename T, typename A,
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
+    inline
+    Status receive (const unsigned int src_processor_id,
+                    std::vector<T,A> & buf,
+                    const NotADataType &,
+                    const MessageTag & tag) const;
+
     template <typename T, typename A>
     inline
     void receive (const unsigned int src_processor_id,

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -435,6 +435,7 @@
     void broadcast(std::set<T,C,A> &data,
                    const unsigned int root_id=0,
                    const bool identical_sizes=false) const;
+#endif // TIMPI_HAVE_MPI
 
 
     // In new overloaded function template entries we have to
@@ -516,6 +517,5 @@
                       std::vector<std::vector<T,A1>,A2> &recv,
                       const MessageTag &send_tag = no_tag,
                       const MessageTag &recv_tag = any_tag) const;
-#endif // TIMPI_HAVE_MPI
 
 #endif // TIMPI_COMMUNICATOR_H

--- a/src/parallel/include/timpi/parallel_communicator_specializations
+++ b/src/parallel/include/timpi/parallel_communicator_specializations
@@ -450,7 +450,10 @@
                       const MessageTag &send_tag = no_tag,
                       const MessageTag &recv_tag = any_tag) const;
 
-    template <typename T1, typename T2, typename A1, typename A2>
+    template <typename T1, typename T2, typename A1, typename A2,
+              typename std::enable_if<std::is_base_of<DataType, StandardType<T1>>::value &&
+                                      std::is_base_of<DataType, StandardType<T2>>::value,
+                                      int>::type = 0>
     inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<T1,A1> & send,
@@ -462,7 +465,32 @@
     // We specialize on the T1==T2 case so that we can handle
     // send_receive-to-self with a plain copy rather than going through
     // MPI.
-    template <typename T, typename A>
+    template <typename T, typename A,
+              typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value,
+                                      int>::type = 0>
+    inline
+    void send_receive(const unsigned int dest_processor_id,
+                      const std::vector<T,A> & send,
+                      const unsigned int source_processor_id,
+                      std::vector<T,A> &recv,
+                      const MessageTag &send_tag = no_tag,
+                      const MessageTag &recv_tag = any_tag) const;
+
+    template <typename T1, typename T2, typename A1, typename A2,
+              typename std::enable_if<Has_buffer_type<Packing<T1>>::value &&
+                                      Has_buffer_type<Packing<T2>>::value, int>::type = 0>
+    inline
+    void send_receive(const unsigned int dest_processor_id,
+                      const std::vector<T1,A1> & send,
+                      const unsigned int source_processor_id,
+                      std::vector<T2,A2> &recv,
+                      const MessageTag &send_tag = no_tag,
+                      const MessageTag &recv_tag = any_tag) const;
+
+    // We specialize on the T1==T2 case so that the other T1==T2
+    // specialization doesn't override the Packing specialization
+    template <typename T, typename A,
+              typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
     inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<T,A> & send,

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -1428,13 +1428,12 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
                                        const std::vector<std::vector<T,A1>,A2> & sendvec,
                                        const unsigned int source_processor_id,
                                        std::vector<std::vector<T,A1>,A2> & recv,
-                                       const MessageTag & /* send_tag */,
-                                       const MessageTag & /* recv_tag */) const
+                                       const MessageTag & send_tag,
+                                       const MessageTag & recv_tag) const
 {
-  // FIXME - why aren't we honoring send_tag and recv_tag here?
   send_receive_vec_of_vec
     (dest_processor_id, sendvec, source_processor_id, recv,
-     no_tag, any_tag, *this);
+     send_tag, recv_tag, *this);
 }
 
 

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -1313,8 +1313,52 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
 }
 
 
+template <typename T1, typename T2, typename A1, typename A2,
+          typename std::enable_if<Has_buffer_type<Packing<T1>>::value &&
+                                  Has_buffer_type<Packing<T2>>::value, int>::type>
+inline
+void
+Communicator::send_receive(const unsigned int dest_processor_id,
+                           const std::vector<T1,A1> & send,
+                           const unsigned int source_processor_id,
+                           std::vector<T2,A2> &recv,
+                           const MessageTag &send_tag,
+                           const MessageTag &recv_tag) const
+{
+  this->send_receive_packed_range(dest_processor_id, (void *)(nullptr),
+                                  send.begin(), send.end(),
+                                  source_processor_id, (void *)(nullptr),
+                                  std::back_inserter(recv),
+                                  (const T2 *)(nullptr),
+                                  send_tag, recv_tag);
+}
 
-template <typename T1, typename T2>
+
+template <typename T, typename A,
+          typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type>
+inline
+void
+Communicator::send_receive(const unsigned int dest_processor_id,
+                           const std::vector<T,A> & send,
+                           const unsigned int source_processor_id,
+                           std::vector<T,A> &recv,
+                           const MessageTag &send_tag,
+                           const MessageTag &recv_tag) const
+{
+  this->send_receive_packed_range(dest_processor_id, (void *)(nullptr),
+                                  send.begin(), send.end(),
+                                  source_processor_id, (void *)(nullptr),
+                                  std::back_inserter(recv),
+                                  (const T *)(nullptr),
+                                  send_tag, recv_tag);
+}
+
+
+
+template <typename T1, typename T2,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T1>>::value &&
+                                  std::is_base_of<DataType, StandardType<T2>>::value,
+                                  int>::type>
 inline void Communicator::send_receive(const unsigned int dest_processor_id,
                                        const T1 & sendvec,
                                        const unsigned int source_processor_id,
@@ -1354,7 +1398,9 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
 // We specialize on the T1==T2 case so that we can handle
 // send_receive-to-self with a plain copy rather than going through
 // MPI.
-template <typename T, typename A>
+template <typename T, typename A,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value,
+                                  int>::type>
 inline void Communicator::send_receive(const unsigned int dest_processor_id,
                                        const std::vector<T,A> & sendvec,
                                        const unsigned int source_processor_id,
@@ -1383,9 +1429,10 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
 }
 
 
-// This is both a declaration and definition for a new overloaded
-// function template, so we have to re-specify the default arguments
-template <typename T1, typename T2, typename A1, typename A2>
+template <typename T1, typename T2, typename A1, typename A2,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T1>>::value &&
+                                  std::is_base_of<DataType, StandardType<T2>>::value,
+                                  int>::type>
 inline void Communicator::send_receive(const unsigned int dest_processor_id,
                                        const std::vector<T1,A1> & sendvec,
                                        const unsigned int source_processor_id,

--- a/src/parallel/include/timpi/serial_implementation.h
+++ b/src/parallel/include/timpi/serial_implementation.h
@@ -182,7 +182,10 @@ Communicator::receive_packed_range(const unsigned int,
 /**
  * Send-receive data from one processor.
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T1>>::value &&
+                                  std::is_base_of<DataType, StandardType<T2>>::value,
+                                  int>::type>
 inline void Communicator::send_receive (const unsigned int timpi_dbg_var(send_tgt),
                                         const T1 & send_val,
                                         const unsigned int timpi_dbg_var(recv_source),
@@ -194,6 +197,117 @@ inline void Communicator::send_receive (const unsigned int timpi_dbg_var(send_tg
   timpi_assert_equal_to (recv_source, 0);
   recv_val = send_val;
 }
+
+template <typename T1, typename T2, typename A1, typename A2>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<T1,A1> & send,
+                                const DataType &,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<T2,A2> &recv,
+                                const DataType &,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+template <typename T1, typename T2, typename A1, typename A2,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T1>>::value &&
+                                  std::is_base_of<DataType, StandardType<T2>>::value,
+                                  int>::type>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<T1,A1> & send,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<T2,A2> &recv,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+template <typename T, typename A,
+          typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value,
+                                  int>::type>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<T,A> & send,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<T,A> &recv,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+template <typename T1, typename T2, typename A1, typename A2,
+          typename std::enable_if<Has_buffer_type<Packing<T1>>::value &&
+                                  Has_buffer_type<Packing<T2>>::value, int>::type>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<T1,A1> & send,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<T2,A2> &recv,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+template <typename T, typename A,
+          typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<T,A> & send,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<T,A> &recv,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+template <typename T1, typename T2, typename A1, typename A2, typename A3, typename A4>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<std::vector<T1,A1>,A2> & send,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<std::vector<T2,A3>,A4> &recv,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+template <typename T, typename A1, typename A2>
+inline
+void Communicator::send_receive(const unsigned int timpi_dbg_var(dest_processor_id),
+                                const std::vector<std::vector<T,A1>,A2> & send,
+                                const unsigned int timpi_dbg_var(source_processor_id),
+                                std::vector<std::vector<T,A1>,A2> &recv,
+                                const MessageTag &,
+                                const MessageTag &) const
+{
+  timpi_assert_equal_to (dest_processor_id, 0);
+  timpi_assert_equal_to (source_processor_id, 0);
+  recv = send;
+}
+
+
+
 
 /**
  * Send-receive range-of-pointers from one processor.

--- a/src/parallel/src/communicator.C
+++ b/src/parallel/src/communicator.C
@@ -210,7 +210,6 @@ void Communicator::assign(const communicator & comm)
     }
   _next_tag = _max_tag / 2;
 #endif
-  _send_mode = DEFAULT;
 }
 
 

--- a/src/parallel/src/communicator.C
+++ b/src/parallel/src/communicator.C
@@ -63,6 +63,7 @@ Communicator::Communicator () :
   _rank(0),
   _size(1),
   _send_mode(DEFAULT),
+  _sync_type(NBX),
   used_tag_values(),
   _next_tag(0),
   _max_tag(std::numeric_limits<int>::max()),
@@ -76,6 +77,7 @@ Communicator::Communicator (const communicator & comm) :
   _rank(0),
   _size(1),
   _send_mode(DEFAULT),
+  _sync_type(NBX),
   used_tag_values(),
   _next_tag(0),
   _max_tag(std::numeric_limits<int>::max()),
@@ -102,6 +104,7 @@ void Communicator::split(int color, int key, Communicator & target) const
   target.assign(newcomm);
   target._I_duped_it = (color != MPI_UNDEFINED);
   target.send_mode(this->send_mode());
+  target.sync_type(this->sync_type());
 }
 
 
@@ -115,6 +118,7 @@ void Communicator::split_by_type(int split_type, int key, info i, Communicator &
   target.assign(newcomm);
   target._I_duped_it = (split_type != MPI_UNDEFINED);
   target.send_mode(this->send_mode());
+  target.sync_type(this->sync_type());
 }
 
 #else
@@ -134,6 +138,7 @@ void Communicator::duplicate(const Communicator & comm)
 {
   this->duplicate(comm._communicator);
   this->send_mode(comm.send_mode());
+  this->sync_type(comm.sync_type());
 }
 
 

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -571,5 +571,15 @@ int main(int argc, const char * const * argv)
   testPull();
   testPullPacked();
 
+  TestCommWorld->sync_type(Communicator::ALLTOALL_COUNTS);
+  testPush();
+  testPull();
+  testPullPacked();
+
+  TestCommWorld->sync_type(Communicator::BLOCKING);
+  testPush();
+  testPull();
+  testPullPacked();
+
   return 0;
 }

--- a/test/dispatch_to_packed_unit.C
+++ b/test/dispatch_to_packed_unit.C
@@ -576,7 +576,7 @@ int main(int argc, const char * const * argv)
   testPull();
   testPullPacked();
 
-  TestCommWorld->sync_type(Communicator::BLOCKING);
+  TestCommWorld->sync_type(Communicator::SENDRECEIVE);
   testPush();
   testPull();
   testPullPacked();

--- a/test/packed_range_unit.C
+++ b/test/packed_range_unit.C
@@ -755,7 +755,7 @@ int main(int argc, const char * const * argv)
   testPushPackedMoveOversized();
 #endif
 
-  TestCommWorld->sync_type(Communicator::BLOCKING);
+  TestCommWorld->sync_type(Communicator::SENDRECEIVE);
   testPushPacked();
   testPushPackedOversized();
   testPushPackedNested();

--- a/test/packed_range_unit.C
+++ b/test/packed_range_unit.C
@@ -731,6 +731,31 @@ int main(int argc, const char * const * argv)
   testNullSendReceive();
   testContainerAllGather();
   testContainerSendReceive();
+
+  testPushPacked();
+  testPushPackedOversized();
+  testPushPackedNested();
+  testPushPackedDispatch();
+  testPushPackedOneTuple();
+  testPushPackedFailureCase();
+#if __cplusplus > 201402L
+  testPushPackedMove();
+  testPushPackedMoveOversized();
+#endif
+
+  TestCommWorld->sync_type(Communicator::ALLTOALL_COUNTS);
+  testPushPacked();
+  testPushPackedOversized();
+  testPushPackedNested();
+  testPushPackedDispatch();
+  testPushPackedOneTuple();
+  testPushPackedFailureCase();
+#if __cplusplus > 201402L
+  testPushPackedMove();
+  testPushPackedMoveOversized();
+#endif
+
+  TestCommWorld->sync_type(Communicator::BLOCKING);
   testPushPacked();
   testPushPackedOversized();
   testPushPackedNested();

--- a/test/parallel_sync_unit.C
+++ b/test/parallel_sync_unit.C
@@ -227,8 +227,8 @@ Communicator *TestCommWorld;
     // because of C++11's guarantees regarding preservation of insert
     // ordering in multimaps, combined with MPI's guarantees about
     // non-overtaking ... but we do receives in a different order with
-    // BLOCKING mode, so let's skip oversized test there.
-    if (TestCommWorld->sync_type() == Communicator::BLOCKING &&
+    // SENDRECEIVE mode, so let's skip oversized test there.
+    if (TestCommWorld->sync_type() == Communicator::SENDRECEIVE &&
         M > int(TestCommWorld->size()))
       return;
 
@@ -362,8 +362,8 @@ Communicator *TestCommWorld;
     // because of C++11's guarantees regarding preservation of insert
     // ordering in multimaps, combined with MPI's guarantees about
     // non-overtaking ... but we do receives in a different order with
-    // BLOCKING mode, so let's skip oversized test there.
-    if (TestCommWorld->sync_type() == Communicator::BLOCKING &&
+    // SENDRECEIVE mode, so let's skip oversized test there.
+    if (TestCommWorld->sync_type() == Communicator::SENDRECEIVE &&
         M > int(TestCommWorld->size()))
       return;
 
@@ -449,8 +449,8 @@ Communicator *TestCommWorld;
     // because of C++11's guarantees regarding preservation of insert
     // ordering in multimaps, combined with MPI's guarantees about
     // non-overtaking ... but we do receives in a different order with
-    // BLOCKING mode, so let's skip this test there.
-    if (TestCommWorld->sync_type() == Communicator::BLOCKING)
+    // SENDRECEIVE mode, so let's skip this test there.
+    if (TestCommWorld->sync_type() == Communicator::SENDRECEIVE)
       return;
 
     std::multimap<processor_id_type, std::vector<unsigned int> > data, received_data;
@@ -534,8 +534,8 @@ Communicator *TestCommWorld;
     // because of C++11's guarantees regarding preservation of insert
     // ordering in multimaps, combined with MPI's guarantees about
     // non-overtaking ... but we do receives in a different order with
-    // BLOCKING mode, so let's skip this test there.
-    if (TestCommWorld->sync_type() == Communicator::BLOCKING)
+    // SENDRECEIVE mode, so let's skip this test there.
+    if (TestCommWorld->sync_type() == Communicator::SENDRECEIVE)
       return;
 
     std::multimap<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
@@ -651,7 +651,7 @@ int main(int argc, const char * const * argv)
   TestCommWorld->sync_type(Communicator::ALLTOALL_COUNTS);
   run_tests();
 
-  TestCommWorld->sync_type(Communicator::BLOCKING);
+  TestCommWorld->sync_type(Communicator::SENDRECEIVE);
   run_tests();
 
   return 0;

--- a/test/parallel_sync_unit.C
+++ b/test/parallel_sync_unit.C
@@ -223,6 +223,15 @@ Communicator *TestCommWorld;
 
   void testPullImpl(int M)
   {
+    // Oversized pulls are well-defined with NBX and ALLTOALL_COUNTS
+    // because of C++11's guarantees regarding preservation of insert
+    // ordering in multimaps, combined with MPI's guarantees about
+    // non-overtaking ... but we do receives in a different order with
+    // BLOCKING mode, so let's skip oversized test there.
+    if (TestCommWorld->sync_type() == Communicator::BLOCKING &&
+        M > int(TestCommWorld->size()))
+      return;
+
     std::map<processor_id_type, std::vector<unsigned int> > data, received_data;
 
     fill_scalar_data(data, M);
@@ -297,11 +306,11 @@ Communicator *TestCommWorld;
       (processor_id_type pid,
        const typename std::vector<std::vector<unsigned int>> & vecvec_received)
       {
-        auto & vec = received_data[pid];
-        vec.insert(vec.end(), vecvec_received[0].begin(), vecvec_received[0].end());
         TIMPI_UNIT_ASSERT(vecvec_received.size() == std::size_t(2));
         TIMPI_UNIT_ASSERT(vecvec_received[1].size() == std::size_t(1));
         TIMPI_UNIT_ASSERT(vecvec_received[0][0] == vecvec_received[1][0]);
+        auto & vec = received_data[pid];
+        vec.insert(vec.end(), vecvec_received[0].begin(), vecvec_received[0].end());
       };
 
     TIMPI::push_parallel_vector_data(*TestCommWorld, data, collect_data);
@@ -349,6 +358,15 @@ Communicator *TestCommWorld;
 
   void testPullVecVecImpl(int M)
   {
+    // Oversized pulls are well-defined with NBX and ALLTOALL_COUNTS
+    // because of C++11's guarantees regarding preservation of insert
+    // ordering in multimaps, combined with MPI's guarantees about
+    // non-overtaking ... but we do receives in a different order with
+    // BLOCKING mode, so let's skip oversized test there.
+    if (TestCommWorld->sync_type() == Communicator::BLOCKING &&
+        M > int(TestCommWorld->size()))
+      return;
+
     std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data;
     std::map<processor_id_type, std::vector<std::vector<unsigned int>>> received_data;
 
@@ -427,9 +445,14 @@ Communicator *TestCommWorld;
     const int size = TestCommWorld->size(),
               rank = TestCommWorld->rank();
 
-    // This is going to make sense because of C++11's guarantees
-    // regarding preservation of insert ordering in multimaps,
-    // combined with MPI's guarantees about non-overtaking
+    // This is going to be well-defined with NBX and ALLTOALL_COUNTS
+    // because of C++11's guarantees regarding preservation of insert
+    // ordering in multimaps, combined with MPI's guarantees about
+    // non-overtaking ... but we do receives in a different order with
+    // BLOCKING mode, so let's skip this test there.
+    if (TestCommWorld->sync_type() == Communicator::BLOCKING)
+      return;
+
     std::multimap<processor_id_type, std::vector<unsigned int> > data, received_data;
 
     fill_scalar_data(data, M);
@@ -507,9 +530,14 @@ Communicator *TestCommWorld;
     const int size = TestCommWorld->size(),
               rank = TestCommWorld->rank();
 
-    // This is going to make sense because of C++11's guarantees
-    // regarding preservation of insert ordering in multimaps,
-    // combined with MPI's guarantees about non-overtaking
+    // This is going to be well-defined with NBX and ALLTOALL_COUNTS
+    // because of C++11's guarantees regarding preservation of insert
+    // ordering in multimaps, combined with MPI's guarantees about
+    // non-overtaking ... but we do receives in a different order with
+    // BLOCKING mode, so let's skip this test there.
+    if (TestCommWorld->sync_type() == Communicator::BLOCKING)
+      return;
+
     std::multimap<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
 
     fill_vector_data(data, M);
@@ -591,11 +619,8 @@ Communicator *TestCommWorld;
     testPushMultimapVecVecImpl((TestCommWorld->size() + 4) * 2);
   }
 
-int main(int argc, const char * const * argv)
+void run_tests()
 {
-  TIMPI::TIMPIInit init(argc, argv);
-  TestCommWorld = &init.comm();
-
   testPush();
   testPushMove();
   testPull();
@@ -614,6 +639,20 @@ int main(int argc, const char * const * argv)
   testPullVecVecOversized();
   testPushMultimapOversized();
   testPushMultimapVecVecOversized();
+}
+
+int main(int argc, const char * const * argv)
+{
+  TIMPI::TIMPIInit init(argc, argv);
+  TestCommWorld = &init.comm();
+
+  run_tests();
+
+  TestCommWorld->sync_type(Communicator::ALLTOALL_COUNTS);
+  run_tests();
+
+  TestCommWorld->sync_type(Communicator::BLOCKING);
+  run_tests();
 
   return 0;
 }


### PR DESCRIPTION
This might be interesting when benchmarking the new algorithms, and it might be useful when debugging weird parallel failures or MPI stacks, or it might only be useful because it adds test coverage for a bunch of previously uncovered overloads.