### PR TITLE
Avoid shadowing send()

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -912,9 +912,9 @@ public:
                                     int>::type = 0>
   inline
   void send_receive(const unsigned int dest_processor_id,
-                    const T1 & send,
+                    const T1 & send_data,
                     const unsigned int source_processor_id,
-                    T2 & recv,
+                    T2 & recv_data,
                     const MessageTag & send_tag = no_tag,
                     const MessageTag & recv_tag = any_tag) const;
 
@@ -977,10 +977,10 @@ public:
   template <typename T1, typename T2>
   inline
   void send_receive(const unsigned int dest_processor_id,
-                    const T1 & send,
+                    const T1 & send_data,
                     const DataType & type1,
                     const unsigned int source_processor_id,
-                    T2 & recv,
+                    T2 & recv_data,
                     const DataType & type2,
                     const MessageTag & send_tag = no_tag,
                     const MessageTag & recv_tag = any_tag) const;
@@ -991,7 +991,7 @@ public:
    */
   template <typename T, typename A>
   inline void gather(const unsigned int root_id,
-                     const T & send,
+                     const T & send_data,
                      std::vector<T,A> & recv) const;
 
   /**
@@ -1001,8 +1001,8 @@ public:
    */
   template <typename T, typename A>
   inline void gather(const unsigned int root_id,
-                     const std::basic_string<T> & send,
-                     std::vector<std::basic_string<T>,A> & recv,
+                     const std::basic_string<T> & send_data,
+                     std::vector<std::basic_string<T>,A> & recv_data,
                      const bool identical_buffer_sizes=false) const;
 
   /**
@@ -1048,8 +1048,8 @@ public:
    */
   template <typename T, typename A, typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value,
                                                             int>::type = 0>
-  inline void allgather(const T & send,
-                        std::vector<T,A> & recv) const;
+  inline void allgather(const T & send_data,
+                        std::vector<T,A> & recv_data) const;
 
   /**
    * Take a vector of length \p this->size(), and fill in
@@ -1059,8 +1059,8 @@ public:
    */
   template <typename T, typename A, typename std::enable_if<Has_buffer_type<Packing<T>>::value,
                                                             int>::type = 0>
-  inline void allgather(const T & send,
-                        std::vector<T,A> & recv) const;
+  inline void allgather(const T & send_data,
+                        std::vector<T,A> & recv_data) const;
 
   /**
    * The allgather overload for string types has an optional
@@ -1068,8 +1068,8 @@ public:
    * same length.
    */
   template <typename T, typename A>
-  inline void allgather(const std::basic_string<T> & send,
-                        std::vector<std::basic_string<T>,A> & recv,
+  inline void allgather(const std::basic_string<T> & send_data,
+                        std::vector<std::basic_string<T>,A> & recv_data,
                         const bool identical_buffer_sizes=false) const;
 
   /**
@@ -1110,8 +1110,8 @@ public:
    */
   template <typename T, typename A1, typename A2,
             typename std::enable_if<std::is_base_of<DataType, StandardType<T>>::value, int>::type = 0>
-  inline void allgather(const std::vector<T,A1> & send,
-                        std::vector<std::vector<T,A1>, A2> & recv,
+  inline void allgather(const std::vector<T,A1> & send_data,
+                        std::vector<std::vector<T,A1>, A2> & recv_data,
                         const bool identical_buffer_sizes = false) const;
 
   /**
@@ -1120,8 +1120,8 @@ public:
    */
   template <typename T, typename A1, typename A2,
             typename std::enable_if<Has_buffer_type<Packing<T>>::value, int>::type = 0>
-  inline void allgather(const std::vector<T,A1> & send,
-                        std::vector<std::vector<T,A1>, A2> & recv,
+  inline void allgather(const std::vector<T,A1> & send_data,
+                        std::vector<std::vector<T,A1>, A2> & recv_data,
                         const bool identical_buffer_sizes = false) const;
 
   /**

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -145,9 +145,9 @@ inline void unpack_vector_bool(const std::vector<T,A1> & vec_in,
 // send_receive of (vector<vector<T>>,vector<vector<T>>)
 template <typename T1, typename T2, typename A1, typename A2, typename A3, typename A4>
 inline void send_receive_vec_of_vec(const unsigned int dest_processor_id,
-                                    const std::vector<std::vector<T1,A1>,A2> & send,
+                                    const std::vector<std::vector<T1,A1>,A2> & send_data,
                                     const unsigned int source_processor_id,
-                                    std::vector<std::vector<T2,A3>,A4> & recv,
+                                    std::vector<std::vector<T2,A3>,A4> & recv_data,
                                     const TIMPI::MessageTag & send_tag,
                                     const TIMPI::MessageTag & recv_tag,
                                     const TIMPI::Communicator & comm)
@@ -157,13 +157,13 @@ inline void send_receive_vec_of_vec(const unsigned int dest_processor_id,
   if (dest_processor_id   == comm.rank() &&
       source_processor_id == comm.rank())
     {
-      recv = send;
+      recv_data = send_data;
       return;
     }
 
   TIMPI::Request req;
-  comm.send (dest_processor_id, send, req, send_tag);
-  comm.receive (source_processor_id, recv, recv_tag);
+  comm.send (dest_processor_id, send_data, req, send_tag);
+  comm.receive (source_processor_id, recv_data, recv_tag);
   req.wait();
 }
 
@@ -1319,16 +1319,16 @@ template <typename T1, typename T2, typename A1, typename A2,
 inline
 void
 Communicator::send_receive(const unsigned int dest_processor_id,
-                           const std::vector<T1,A1> & send,
+                           const std::vector<T1,A1> & send_data,
                            const unsigned int source_processor_id,
-                           std::vector<T2,A2> &recv,
+                           std::vector<T2,A2> &recv_data,
                            const MessageTag &send_tag,
                            const MessageTag &recv_tag) const
 {
   this->send_receive_packed_range(dest_processor_id, (void *)(nullptr),
-                                  send.begin(), send.end(),
+                                  send_data.begin(), send_data.end(),
                                   source_processor_id, (void *)(nullptr),
-                                  std::back_inserter(recv),
+                                  std::back_inserter(recv_data),
                                   (const T2 *)(nullptr),
                                   send_tag, recv_tag);
 }
@@ -1339,16 +1339,16 @@ template <typename T, typename A,
 inline
 void
 Communicator::send_receive(const unsigned int dest_processor_id,
-                           const std::vector<T,A> & send,
+                           const std::vector<T,A> & send_data,
                            const unsigned int source_processor_id,
-                           std::vector<T,A> &recv,
+                           std::vector<T,A> &recv_data,
                            const MessageTag &send_tag,
                            const MessageTag &recv_tag) const
 {
   this->send_receive_packed_range(dest_processor_id, (void *)(nullptr),
-                                  send.begin(), send.end(),
+                                  send_data.begin(), send_data.end(),
                                   source_processor_id, (void *)(nullptr),
-                                  std::back_inserter(recv),
+                                  std::back_inserter(recv_data),
                                   (const T *)(nullptr),
                                   send_tag, recv_tag);
 }


### PR DESCRIPTION
Newer compilers don't seem to complain about function parameters shadowing other function names, but gcc 7.5 doesn't like seeing "send" in one of our new overload implementations.  Let's just rename it everywhere.