### PR TITLE
Assert !sending empty vectors even with NBX

### DIFF
--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -248,6 +248,9 @@ push_parallel_nbx_helper(const Communicator & comm,
       processor_id_type dest_pid = datapair.first % num_procs;
       auto & datum = datapair.second;
 
+      // Don't give us empty vectors to send
+      timpi_assert_greater(datum.size(), 0);
+
       // Just act on data if the user requested a send-to-self
       if (dest_pid == comm.rank())
         act_on_data(dest_pid, std::move(datum));


### PR DESCRIPTION
Logan got bit by this in the ray tracing code.

In a sense this is making the sync code less useful, because someone could be legitimately sending a message with an empty container (just as we tend to attach special meaning to a nullptr) ... but more likely an empty container is a performance bug; he says it was in his cases.

Also, we *can't* support sending empty containers as messages in the round-robin backend, so if we want to be able to swap that in we need the same restrictions elsewhere.

We do fear that some code will only generate empty sends at high processor counts, making assertion failures here tricky to debug, but since an assertion will never bring down an opt-mode simulation, that should be reasonable enough.