### PR TITLE
Add Communicator::sync_type setter via a string

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -336,6 +336,13 @@ public:
   void sync_type (const SyncType st) { _sync_type = st; }
 
   /**
+   * Sets the sync type used for sync operations via a string.
+   *
+   * Useful for changing the sync type via a CLI arg or parameter.
+   */
+  void sync_type (const std::string & st);
+
+  /**
    * Gets the user-requested SyncType.
    */
   SyncType sync_type() const { return _sync_type; }

--- a/src/parallel/src/communicator.C
+++ b/src/parallel/src/communicator.C
@@ -452,4 +452,17 @@ void Communicator::maxloc(bool & r,
 }
 
 
+void Communicator::sync_type(const std::string & st)
+{
+  SyncType type = NBX;
+  if (st == "sendreceive")
+    type = SENDRECEIVE;
+  else if (st == "alltoall")
+    type = ALLTOALL_COUNTS;
+  else if (st != "nbx")
+    timpi_error_msg("Unrecognized TIMPI sync type " << st);
+  this->sync_type(type);
+}
+
+
 } // namespace TIMPI

--- a/test/parallel_sync_unit.C
+++ b/test/parallel_sync_unit.C
@@ -619,6 +619,22 @@ Communicator *TestCommWorld;
     testPushMultimapVecVecImpl((TestCommWorld->size() + 4) * 2);
   }
 
+
+  void testStringSyncType()
+  {
+    Communicator comm;
+    comm.duplicate(*TestCommWorld);
+
+    comm.sync_type("nbx");
+    TIMPI_UNIT_ASSERT(comm.sync_type() == Communicator::NBX);
+
+    comm.sync_type("sendreceive");
+    TIMPI_UNIT_ASSERT(comm.sync_type() == Communicator::SENDRECEIVE);
+
+    comm.sync_type("alltoall");
+    TIMPI_UNIT_ASSERT(comm.sync_type() == Communicator::ALLTOALL_COUNTS);
+  }
+
 void run_tests()
 {
   testPush();
@@ -639,6 +655,8 @@ void run_tests()
   testPullVecVecOversized();
   testPushMultimapOversized();
   testPushMultimapVecVecOversized();
+
+  testStringSyncType();
 }
 
 int main(int argc, const char * const * argv)


### PR DESCRIPTION
This better enables setting this sync type via parameters or cli args.