### PR TITLE
Add missing inline keyword

### DIFF
--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -212,6 +212,7 @@ void pull_parallel_vector_data(const Communicator & comm,
 // Separate namespace for not-for-public-use helper functions
 namespace detail {
 
+inline
 void
 empty_send_assertion (const Communicator & comm,
                       processor_id_type empty_target_pid)

--- a/src/algorithms/include/timpi/parallel_sync.h
+++ b/src/algorithms/include/timpi/parallel_sync.h
@@ -212,6 +212,7 @@ void pull_parallel_vector_data(const Communicator & comm,
 // Separate namespace for not-for-public-use helper functions
 namespace detail {
 
+#ifndef NDEBUG
 inline
 void
 empty_send_assertion (const Communicator & comm,
@@ -226,6 +227,7 @@ empty_send_assertion (const Communicator & comm,
   timpi_assert_msg(!someone_found_empty_send,
                    "Some rank(s) sent empty data!" + err_msg.str());
 }
+#endif
 
 template <typename MapToContainers,
           typename SendFunctor,


### PR DESCRIPTION
This wasn't a problem when the function was only getting invoked via one object file's main(), but "duplicate symbol" becomes a problem when it's getting invoked via a dozen different compliation units in the same library downstream.