### PR TITLE
Use FPE-safety flags when compiling TIMPI

### DIFF
--- a/m4/timpi_set_cxx_flags.m4
+++ b/m4/timpi_set_cxx_flags.m4
@@ -23,6 +23,13 @@ AC_DEFUN([TIMPI_SET_CXX_FLAGS],
 [
   ACSM_SET_CXX_FLAGS
 
+  #-----------------------------------------------------
+  # Add compiler flags to respect IEEE FPE behavior.
+  # This probably doesn't affect TIMPI directly but I'd
+  # hate to be surprised by it later.
+  #-----------------------------------------------------
+  ACSM_SET_FPE_SAFETY_FLAGS
+
   ACSM_SET_GLIBCXX_DEBUG_FLAGS
 
   CXXFLAGS_OPT="$ACSM_CXXFLAGS_OPT"


### PR DESCRIPTION
I don't think this is likely to ever be important, since we don't enable FPE in our test suite and we're surely never going to be doing vectorizable operations in the tiny parts of the TIMPI library that aren't header-only ... but I do want to keep ACSM in sync, and if FPE safety in TIMPI *is* ever important I'd rather we be too safe than not-safe-enough.