### PR TITLE
Get a clean `make check` from NVidia HPC SDK 24.7

### DIFF
--- a/src/parallel/src/request.C
+++ b/src/parallel/src/request.C
@@ -128,7 +128,7 @@ Status Request::wait ()
       _prior_request.reset(nullptr);
     }
 
-  Status stat;
+  Status stat {};
 #ifdef TIMPI_HAVE_MPI
   timpi_call_mpi
     (MPI_Wait (&_request, stat.get()));


### PR DESCRIPTION
Only one new compiler warning this time.