### PR TITLE
Assert comm size is strictly greater than 0

### DIFF
--- a/src/parallel/src/communicator.C
+++ b/src/parallel/src/communicator.C
@@ -192,7 +192,7 @@ void Communicator::assign(const communicator & comm)
       timpi_call_mpi
         (MPI_Comm_size(_communicator, &i));
 
-      timpi_assert_greater_equal (i, 0);
+      timpi_assert_greater (i, 0);
       _size = cast_int<processor_id_type>(i);
 
       timpi_call_mpi


### PR DESCRIPTION
This made me doubt for a second about libMesh/libmesh#4041 but I'm pretty sure the communicator must include at least the querying process, as we shielded with `_communicator != MPI_COMM_NULL`.