### PR TITLE
Fix uninitialized warning

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -205,7 +205,12 @@ public:
 
   processor_id_type rank() const { return _rank; }
 
+#ifdef TIMPI_HAVE_MPI
   processor_id_type size() const { return _size; }
+#else
+  // Help the compiler optimize in serial
+  constexpr processor_id_type size() const { return 1; }
+#endif
 
   /**
    * Whether to use default or synchronous sends?

--- a/src/parallel/include/timpi/parallel_implementation.h
+++ b/src/parallel/include/timpi/parallel_implementation.h
@@ -2633,6 +2633,7 @@ inline void Communicator::sum(const T & r,
                               T & o,
                               Request & req) const
 {
+#ifdef TIMPI_HAVE_MPI
   if (this->size() > 1)
     {
       TIMPI_LOG_SCOPE("sum()", "Parallel");
@@ -2645,6 +2646,7 @@ inline void Communicator::sum(const T & r,
                          req.get()));
     }
   else
+#endif
     {
       o = r;
       req = Request::null_request;


### PR DESCRIPTION
Otherwise, the compiler (at least gcc 13.3) can't prove we're not in the parallel branch, and it notices that the parallel branch doesn't touch its output, and it emits a maybe-uninitialized warning in a unit tests where we didn't initialize the output variable ourselves.

I considered adding ifdef blocks to a zillion other cases here as well, since "the compiler can't prove we're not in the parallel branch" has optimization implications as well, but it turns out that a better solution is "help the compiler prove we're in the parallel branch", so I added that instead, and verified that (at least with gcc 13.3) it also is sufficient to fix the maybe-uninitialized warning, which at least implies that *part* of the compiler code can elide an `if (1 > 1)` block.  I'll leave the first commit in anyway too, for redundancy in case other compilers aren't as clever.