### PR TITLE
Raise coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ lcov-report:
 	@mkdir -p $(lcov_dir)
 	lcov --compat-libtool --directory . --capture --output-file $(lcov_dir)/lcov.info
 	lcov --list-full-path -l $(lcov_dir)/lcov.info | grep -v "`cd -P $(top_srcdir)/src && pwd`" | cut -d\| -f1 > $(lcov_dir)/remove
-	lcov -q -r $(lcov_dir)/lcov.info `cat $(lcov_dir)/remove` > $(lcov_dir)/lcov.cleaned.info
+	lcov --ignore-errors unused -q -r $(lcov_dir)/lcov.info `cat $(lcov_dir)/remove` > $(lcov_dir)/lcov.cleaned.info
 	@rm $(lcov_dir)/remove
 	@mv -f $(lcov_dir)/lcov.cleaned.info $(lcov_dir)/lcov.info
 	genhtml -t "TIMPI" -o $(lcov_dir) $(lcov_dir)/lcov.info

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,8 @@ coverage:
 
 CLEANFILES = src/apps/*.gcda src/apps/*.gcno
 
+.PHONY: lcov-report lcov-reset coverage
+
 endif
 
 

--- a/src/utilities/include/timpi/timpi_version.h.in
+++ b/src/utilities/include/timpi/timpi_version.h.in
@@ -22,17 +22,13 @@
 #define TIMPI_MINOR_VERSION  @GENERIC_MINOR_VERSION@
 #define TIMPI_MICRO_VERSION  @GENERIC_MICRO_VERSION@
 
-#define TIMPI_BUILD_USER     "@BUILD_USER@"
-#define TIMPI_BUILD_ARCH     "@BUILD_ARCH@"
-#define TIMPI_BUILD_HOST     "@BUILD_HOST@"
-#define TIMPI_BUILD_DATE     "@BUILD_DATE@"
-#define TIMPI_BUILD_VERSION  "@BUILD_VERSION@"
-
 #define TIMPI_LIB_VERSION    "@VERSION@"
 #define TIMPI_LIB_RELEASE    "@BUILD_DEVSTATUS@"
 
 #define TIMPI_CXX            "@CXX@"
 #define TIMPI_CXXFLAGS       "@CXXFLAGS@"
+
+#include "timpi/timpi_config.h"
 
 #include <iostream>
 #include <iomanip>
@@ -40,6 +36,7 @@
 namespace TIMPI
 {
   void timpi_version_stdout();
+  std::string timpi_version_string();
   int  get_timpi_version();
 } // end namespace TIMPI
 

--- a/src/utilities/src/timpi_version.C
+++ b/src/utilities/src/timpi_version.C
@@ -17,27 +17,37 @@
 
 #include "timpi/timpi_version.h"
 
+#include <iostream>
+#include <sstream>
+
 namespace TIMPI
 {
 
   void timpi_version_stdout()
   {
-    std::cout << "--------------------------------------------------------" << std::endl;
-    std::cout << "TIMPI Package: Version = " << TIMPI_LIB_VERSION;
-    std::cout << " (" << get_timpi_version() << ")" << std::endl << std::endl;
+    std::cout << timpi_version_string() << std::flush;
+  }
 
-    std::cout << TIMPI_LIB_RELEASE << std::endl << std::endl;
+  std::string timpi_version_string()
+  {
+    std::ostringstream oss;
 
-    std::cout << "Build Date   = " << TIMPI_BUILD_DATE     << std::endl;
-    std::cout << "Build Host   = " << TIMPI_BUILD_HOST     << std::endl;
-    std::cout << "Build User   = " << TIMPI_BUILD_USER     << std::endl;
-    std::cout << "Build Arch   = " << TIMPI_BUILD_ARCH     << std::endl;
-    std::cout << "Build Rev    = " << TIMPI_BUILD_VERSION  << std::endl << std::endl;
+    oss << "--------------------------------------------------------" << std::endl;
+    oss << "TIMPI Package: Version = " << TIMPI_LIB_VERSION;
+    oss << " (" << get_timpi_version() << ")" << std::endl << std::endl;
 
-    std::cout << "C++ Config   = " << TIMPI_CXX << " " << TIMPI_CXXFLAGS << std::endl;
-    std::cout << "--------------------------------------------------------" << std::endl;
+    oss << TIMPI_LIB_RELEASE << std::endl << std::endl;
 
-    return;
+    oss << "Build Date   = " << TIMPI_BUILD_DATE     << std::endl;
+    oss << "Build Host   = " << TIMPI_BUILD_HOST     << std::endl;
+    oss << "Build User   = " << TIMPI_BUILD_USER     << std::endl;
+    oss << "Build Arch   = " << TIMPI_BUILD_ARCH     << std::endl;
+    oss << "Build Rev    = " << TIMPI_BUILD_VERSION  << std::endl << std::endl;
+
+    oss << "C++ Config   = " << TIMPI_CXX << " " << TIMPI_CXXFLAGS << std::endl;
+    oss << "--------------------------------------------------------" << std::endl;
+
+    return oss.str();
   }
 
   int get_timpi_version()

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,12 +48,18 @@ if BUILD_DBG_MODE
   dispatch_to_packed_unit_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
   dispatch_to_packed_unit_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
 
+  utility_unit_dbg_SOURCES = utility_unit.C
+  utility_unit_dbg_LDFLAGS = $(top_builddir)/src/libtimpi_dbg.la
+  utility_unit_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
+  utility_unit_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
+
   check_PROGRAMS += message_tag_unit-dbg
   check_PROGRAMS += packed_range_unit-dbg
   check_PROGRAMS += parallel_sync_unit-dbg
   check_PROGRAMS += parallel_unit-dbg
   check_PROGRAMS += set_unit-dbg
   check_PROGRAMS += dispatch_to_packed_unit-dbg
+  check_PROGRAMS += utility_unit-dbg
 endif
 
 if BUILD_DEVEL_MODE
@@ -87,12 +93,18 @@ if BUILD_DEVEL_MODE
   dispatch_to_packed_unit_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
   dispatch_to_packed_unit_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
 
+  utility_unit_devel_SOURCES = utility_unit.C
+  utility_unit_devel_LDFLAGS = $(top_builddir)/src/libtimpi_devel.la
+  utility_unit_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
+  utility_unit_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
+
   check_PROGRAMS += message_tag_unit-devel
   check_PROGRAMS += packed_range_unit-devel
   check_PROGRAMS += parallel_sync_unit-devel
   check_PROGRAMS += parallel_unit-devel
   check_PROGRAMS += set_unit-devel
   check_PROGRAMS += dispatch_to_packed_unit-devel
+  check_PROGRAMS += utility_unit-devel
 endif
 
 if BUILD_OPT_MODE
@@ -126,12 +138,18 @@ if BUILD_OPT_MODE
   dispatch_to_packed_unit_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
   dispatch_to_packed_unit_opt_CXXFLAGS = $(CXXFLAGS_OPT)
 
+  utility_unit_opt_SOURCES = utility_unit.C
+  utility_unit_opt_LDFLAGS = $(top_builddir)/src/libtimpi_opt.la
+  utility_unit_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
+  utility_unit_opt_CXXFLAGS = $(CXXFLAGS_OPT)
+
   check_PROGRAMS += message_tag_unit-opt
   check_PROGRAMS += packed_range_unit-opt
   check_PROGRAMS += parallel_sync_unit-opt
   check_PROGRAMS += parallel_unit-opt
   check_PROGRAMS += set_unit-opt
   check_PROGRAMS += dispatch_to_packed_unit-opt
+  check_PROGRAMS += utility_unit-opt
 endif
 
 if BUILD_OPROF_MODE
@@ -165,12 +183,18 @@ if BUILD_OPROF_MODE
   dispatch_to_packed_unit_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
   dispatch_to_packed_unit_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 
+  utility_unit_oprof_SOURCES = utility_unit.C
+  utility_unit_oprof_LDFLAGS = $(top_builddir)/src/libtimpi_oprof.la
+  utility_unit_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
+  utility_unit_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
+
   check_PROGRAMS += message_tag_unit-oprof
   check_PROGRAMS += packed_range_unit-oprof
   check_PROGRAMS += parallel_sync_unit-oprof
   check_PROGRAMS += parallel_unit-oprof
   check_PROGRAMS += set_unit-oprof
   check_PROGRAMS += dispatch_to_packed_unit-oprof
+  check_PROGRAMS += utility_unit-oprof
 endif
 
 if BUILD_PROF_MODE
@@ -204,12 +228,18 @@ if BUILD_PROF_MODE
   dispatch_to_packed_unit_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
   dispatch_to_packed_unit_prof_CXXFLAGS = $(CXXFLAGS_PROF)
 
+  utility_unit_prof_SOURCES = utility_unit.C
+  utility_unit_prof_LDFLAGS = $(top_builddir)/src/libtimpi_prof.la
+  utility_unit_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
+  utility_unit_prof_CXXFLAGS = $(CXXFLAGS_PROF)
+
   check_PROGRAMS += message_tag_unit-prof
   check_PROGRAMS += packed_range_unit-prof
   check_PROGRAMS += parallel_sync_unit-prof
   check_PROGRAMS += parallel_unit-prof
   check_PROGRAMS += set_unit-prof
   check_PROGRAMS += dispatch_to_packed_unit-prof
+  check_PROGRAMS += utility_unit-prof
 endif
 
 ######################################################################

--- a/test/message_tag_unit.C
+++ b/test/message_tag_unit.C
@@ -69,6 +69,9 @@ Communicator *TestCommWorld;
 
         TIMPI::MessageTag tag_move = std::move(tag_copy);
         TIMPI_UNIT_ASSERT(i == tag_move.value());
+
+        TIMPI::MessageTag stupidly_manual_tag(i);
+        TIMPI_UNIT_ASSERT(i == stupidly_manual_tag.value());
       }
   }
 

--- a/test/utility_unit.C
+++ b/test/utility_unit.C
@@ -1,0 +1,38 @@
+#include <timpi/timpi.h>
+
+#include <timpi/timpi_version.h>
+
+#define TIMPI_UNIT_ASSERT(expr) \
+  if (!(expr)) \
+    timpi_error();
+
+using namespace TIMPI;
+
+Communicator *TestCommWorld;
+
+  void testVersionString()
+  {
+    std::string build_string = timpi_version_string();
+    TIMPI_UNIT_ASSERT(build_string.find("Version = 1.8.5") != std::string::npos);
+    TIMPI_UNIT_ASSERT(build_string.find("Build Date") != std::string::npos);
+    TIMPI_UNIT_ASSERT(build_string.find("C++ Config") != std::string::npos);
+    TIMPI_UNIT_ASSERT(build_string.find("Using find correctly") == std::string::npos);
+  }
+
+  void testVersionNumber()
+  {
+    int version = get_timpi_version();
+    TIMPI_UNIT_ASSERT(version == 10805);
+  }
+
+
+int main(int argc, const char * const * argv)
+{
+  TIMPI::TIMPIInit init(argc, argv);
+  TestCommWorld = &init.comm();
+
+  testVersionString();
+  testVersionNumber();
+
+  return 0;
+}


### PR DESCRIPTION
After seeing one of those MPI-4-interface bugs make it past our CI before getting tripped in libMesh testing, I decided to try increasing our coverage.

This seems like a losing battle with old-but-misbehaving lcov on our CI boxes and new-but-misbehaving-differently lcov on my workstation, but we should merge what progress I've made.