### PR TITLE
Fix unit tests with C++14 compilers

### DIFF
--- a/test/packed_range_unit.C
+++ b/test/packed_range_unit.C
@@ -223,6 +223,7 @@ Communicator *TestCommWorld;
   // other types.
   void testTupleStringAllGather()
   {
+#ifdef TIMPI_HAVE_CXX17 // static_assert without message
     static_assert(Has_buffer_type<Packing<std::string>>::value);
     static_assert(libMesh::Parallel::TupleHasPacking<std::string>::value);
     static_assert(Has_buffer_type<Packing<std::tuple<std::string>>>::value);
@@ -230,6 +231,7 @@ Communicator *TestCommWorld;
     static_assert(Has_buffer_type<Packing<std::tuple<std::string, std::string>>>::value);
     static_assert(libMesh::Parallel::TupleHasPacking<std::string, std::string, int>::value);
     static_assert(Has_buffer_type<Packing<std::tuple<std::string, std::string, int>>>::value);
+#endif
 
     std::vector<std::tuple<std::string, std::string, int>> sendv(2);
 
@@ -278,8 +280,10 @@ Communicator *TestCommWorld;
   {
     typedef std::tuple<unsigned int, std::vector<std::tuple<char,int,std::size_t>>, unsigned int> send_type;
 
+#ifdef TIMPI_HAVE_CXX17 // static_assert without message
     static_assert(Has_buffer_type<Packing<std::vector<std::tuple<char,int,std::size_t>>>>::value);
     static_assert(Has_buffer_type<Packing<send_type>>::value);
+#endif
 
     std::vector<send_type> sendv(2);
 
@@ -624,6 +628,7 @@ Communicator *TestCommWorld;
   void testPushPackedOneTuple()
   {
     typedef std::tuple<std::unordered_map<unsigned int, std::string>> tuple_type;
+#ifdef TIMPI_HAVE_CXX17 // static_assert without message
     static_assert(Has_buffer_type<Packing<std::string>>::value);
     static_assert(TIMPI::StandardType<std::pair<unsigned int, unsigned int>>::is_fixed_type);
     static_assert(TIMPI::StandardType<std::pair<const unsigned int, unsigned int>>::is_fixed_type);
@@ -635,6 +640,7 @@ Communicator *TestCommWorld;
     static_assert(Has_buffer_type<Packing<std::pair<const unsigned int, std::string>>>::value);
     static_assert(Has_buffer_type<Packing<std::unordered_map<unsigned int, std::string>>>::value);
     static_assert(Has_buffer_type<Packing<tuple_type>>::value);
+#endif
 
     auto fill_tuple = [] (int n)
       {

--- a/test/set_unit.C
+++ b/test/set_unit.C
@@ -98,10 +98,10 @@ void tester(const std::multimap<int, int> & m, int i)
   TIMPI_UNIT_ASSERT( m.count(-1) * 3 == m.size() );
 
   std::bitset<2> found;
-  auto [begin, end] = m.equal_range(i);
-  for (auto it = begin; it != end; ++it)
+  auto pr = m.equal_range(i);
+  for (auto it = pr.first; it != pr.second; ++it)
     {
-      auto [key, val] = *it;
+      auto val = it->second;
       TIMPI_UNIT_ASSERT( val > 3*i && val < 3*i+3 );
       TIMPI_UNIT_ASSERT( !found[val-3*i-1] );
       found[val-3*i-1] = true;
@@ -114,10 +114,10 @@ void tester(const std::unordered_multimap<int, int> & m, int i)
   TIMPI_UNIT_ASSERT( m.count(-1) * 3 == m.size() );
 
   std::bitset<2> found;
-  auto [begin, end] = m.equal_range(i);
-  for (auto it = begin; it != end; ++it)
+  const auto pr = m.equal_range(i);
+  for (auto it = pr.first; it != pr.second; ++it)
     {
-      auto [key, val] = *it;
+      auto val = it->second;
       TIMPI_UNIT_ASSERT( val > 3*i && val < 3*i+3 );
       TIMPI_UNIT_ASSERT( !found[val-3*i-1] );
       found[val-3*i-1] = true;
@@ -223,8 +223,10 @@ void tester(const std::unordered_map<int, std::vector<int>> & m, int i)
     // same surface_ids, the ones from pid 0.
     TIMPI_UNIT_ASSERT( mapset.size() == 1 );
     const std::set<unsigned short> goodset {20201, 60201};
-    for (const auto & [key, boundary_id_set] : mapset)
+    for (const auto & pr : mapset)
     {
+      const auto & key = pr.first;
+      const auto & boundary_id_set = pr.second;
       TIMPI_UNIT_ASSERT( key == 0 );
       TIMPI_UNIT_ASSERT( boundary_id_set == goodset );
     }
@@ -254,8 +256,10 @@ void tester(const std::unordered_map<int, std::vector<int>> & m, int i)
     TIMPI_UNIT_ASSERT( mapmap.size() == 1 );
     const std::map<unsigned short, double> goodmap {{20201, 0.8},
                                                     {60201, 1}};
-    for (const auto & [key, boundary_id_map] : mapmap)
+    for (const auto & pr : mapmap)
     {
+      const auto & key = pr.first;
+      const auto & boundary_id_map = pr.second;
       TIMPI_UNIT_ASSERT( key == 0 );
       TIMPI_UNIT_ASSERT( boundary_id_map == goodmap );
     }


### PR DESCRIPTION
I was about to use a C++17-only feature on purpose, then wondered how many we've been starting to use by accident...