### PR TITLE
Don't provide default Attributes<T>::set_*

### DIFF
--- a/src/parallel/include/timpi/attributes.h
+++ b/src/parallel/include/timpi/attributes.h
@@ -46,8 +46,10 @@ template<typename T>
 struct Attributes
 {
   static const bool has_min_max = false;
-  static void set_lowest(T &) {}
-  static void set_highest(T &) {}
+  /*
+  static void set_lowest(T & x) { x = as_low_as_it_can_be; }
+  static void set_highest(T & x) { x = as_high_as_it_can_be; }
+  */
 };
 
 // ------------------------------------------------------------


### PR DESCRIPTION
We had a bool for code to test before trying to use these, but it's better to just not even *allow* code to try to use these; it's invariably going to be a bug, like the one we just fixed in libMesh.