### PR TITLE
Include cstdint in communicator.h

### DIFF
--- a/src/parallel/include/timpi/communicator.h
+++ b/src/parallel/include/timpi/communicator.h
@@ -29,6 +29,7 @@
 #include "timpi/timpi_macros.h"
 
 // C++ includes
+#include <cstdint>
 #include <map>
 #include <memory> // shared_ptr
 #include <string>


### PR DESCRIPTION
This fixes a compile error I get.

`uint*_t` are used a few lines down for `processor_id_type` typedef.