### PR TITLE
Initialize temp variable in test

### DIFF
--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -278,7 +278,7 @@ void testGather()
 
     // Workaround for spurious warning from operator=
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100366
-    aa x;
+    aa x{{ {0,1,2},{3,4,5} }};
     std::vector<aa> src(3), dest(3,x);
 
     src[0][0][0] = 0;


### PR DESCRIPTION
We had to add this to work around a spurious warning from one compiler; now we're having to change it to work around a different spurious (although much more excusably so) warning from another compiler.